### PR TITLE
add basic shadows for Dark Mode

### DIFF
--- a/dist/src/shadows.d.ts
+++ b/dist/src/shadows.d.ts
@@ -5,4 +5,8 @@ export declare const shadows: {
     large: string;
     input: string;
     button: string;
+    dark: {
+        popover: string;
+        small: string;
+    };
 };

--- a/src/shadows.ts
+++ b/src/shadows.ts
@@ -5,4 +5,9 @@ export const shadows = {
   large: '0 30px 60px rgba(0,0,0,0.12)',
   input: '0 2px 2px 0 rgba(0,0,20,0.015), 0 0 0 1px rgba(0,0,20,0.0075)',
   button: '0 2px 2px 0 rgba(0,0,20,0.015), 0 0 0 1px rgba(0,0,20,0.0075)',
+  
+  dark: {
+    popover: '0 2px 6px rgba(0,0,0,0.35)',
+    small: '0 5px 10px rgba(0,0,0,0.32)',
+  }
 };


### PR DESCRIPTION
Refs: https://github.com/expo/snack/pull/93

This small PR adds tweaked version of `popup` and `small` shadows for Dark Mode. 

Currently in Snack, when using Dark Mode, shadows are disabled (unlike in Light Mode) - I assume that the reason for that is that current shadows were almost non-visible - of course I might be wrong, feel free to correct me 😉 

The proposed Dark Mode shadows uses the same shadow position, radius, color, but have adjusted opacity, which will make the shadows a bit more visible (at least in Snack).

CC: @jonsamp 

## Preview

<img width="227" alt="Screenshot 2021-02-22 115218" src="https://user-images.githubusercontent.com/719641/108698457-71882980-7504-11eb-95f1-db73958b583b.png">

