### PR TITLE
[styleguide] Adds xl/default headers

### DIFF
--- a/packages/styleguide-native/index.ts
+++ b/packages/styleguide-native/index.ts
@@ -4,6 +4,7 @@ import { lightTheme, darkTheme } from './src/styles/themes';
 import { iconSize, borderRadius } from './src/styles/sizing';
 import { spacing } from './src/styles/spacing';
 import { breakpoints } from './src/styles/breakpoints';
+import { typography } from './src/styles/typography';
 
 export * from './src/icons';
 export {
@@ -15,4 +16,5 @@ export {
   palette,
   shadows,
   spacing,
+  typography,
 };

--- a/packages/styleguide-native/src/styles/themes.ts
+++ b/packages/styleguide-native/src/styles/themes.ts
@@ -3,7 +3,6 @@ import { palette } from './palette';
 export const lightTheme = {
   background: {
     default: palette.light.white,
-    canvas: palette.light.gray['000'],
     screen: palette.light.gray[100],
     secondary: palette.light.gray[100],
     tertiary: palette.light.gray[200],
@@ -92,7 +91,6 @@ export const lightTheme = {
 export const darkTheme = {
   background: {
     default: palette.dark.gray['000'],
-    canvas: palette.dark.gray[100],
     screen: palette.dark.gray['000'],
     secondary: palette.dark.gray[200],
     tertiary: palette.dark.gray[300],

--- a/packages/styleguide-native/src/styles/typography.ts
+++ b/packages/styleguide-native/src/styles/typography.ts
@@ -1,0 +1,340 @@
+const baseFontSize = 16;
+
+const fontSizes = {
+  61: {
+    fontSize: 61,
+    lineHeight: 73,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  53: {
+    fontSize: 53,
+    lineHeight: 64,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  49: {
+    fontSize: 49,
+    lineHeight: 59,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  46: {
+    fontSize: 46,
+    lineHeight: 55,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  43: {
+    fontSize: 43,
+    lineHeight: 52,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  39: {
+    fontSize: 39,
+    lineHeight: 51,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  37: {
+    fontSize: 37,
+    lineHeight: 48,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  34: {
+    fontSize: 34,
+    lineHeight: 44,
+    letterSpacing: -0.022 * baseFontSize,
+  },
+  31: {
+    fontSize: 31,
+    lineHeight: 40,
+    letterSpacing: -0.021 * baseFontSize,
+  },
+  29: {
+    fontSize: 29,
+    lineHeight: 38,
+    letterSpacing: -0.021 * baseFontSize,
+  },
+  27: {
+    fontSize: 27,
+    lineHeight: 36,
+    letterSpacing: -0.021 * baseFontSize,
+  },
+  25: {
+    fontSize: 25,
+    lineHeight: 35,
+    letterSpacing: -0.021 * baseFontSize,
+  },
+  23: {
+    fontSize: 23,
+    lineHeight: 32,
+    letterSpacing: -0.019 * baseFontSize,
+  },
+  22: {
+    fontSize: 22,
+    lineHeight: 31,
+    letterSpacing: -0.018 * baseFontSize,
+  },
+  20: {
+    fontSize: 20,
+    lineHeight: 30,
+    letterSpacing: -0.017 * baseFontSize,
+  },
+  19: {
+    fontSize: 19,
+    lineHeight: 29,
+    letterSpacing: -0.015 * baseFontSize,
+  },
+  18: {
+    fontSize: 18,
+    lineHeight: 28,
+    letterSpacing: -0.014 * baseFontSize,
+  },
+  16: {
+    fontSize: 16,
+    lineHeight: 26,
+    letterSpacing: -0.011 * baseFontSize,
+  },
+  15: {
+    fontSize: 15,
+    lineHeight: 24,
+    letterSpacing: -0.009 * baseFontSize,
+  },
+  14: {
+    fontSize: 14,
+    lineHeight: 22,
+    letterSpacing: -0.006 * baseFontSize,
+  },
+  13: {
+    fontSize: 13,
+    lineHeight: 21,
+    letterSpacing: -0.003 * baseFontSize,
+  },
+  12: {
+    fontSize: 12,
+    lineHeight: 19,
+  },
+};
+
+const headers = {
+  xl: {
+    large: {
+      huge: {
+        fontWeight: '900',
+        ...fontSizes[61],
+      },
+      h1: {
+        fontWeight: '600',
+        ...fontSizes[49],
+      },
+      h2: {
+        fontWeight: '600',
+        ...fontSizes[39],
+      },
+      h3: {
+        fontWeight: '600',
+        ...fontSizes[31],
+      },
+      h4: {
+        fontWeight: '600',
+        ...fontSizes[25],
+      },
+      h5: {
+        fontWeight: '600',
+        ...fontSizes[20],
+      },
+      h6: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+    },
+    medium: {
+      huge: {
+        fontWeight: '900',
+        ...fontSizes[53],
+      },
+      h1: {
+        fontWeight: '600',
+        ...fontSizes[43],
+      },
+      h2: {
+        fontWeight: '600',
+        ...fontSizes[34],
+      },
+      h3: {
+        fontWeight: '600',
+        ...fontSizes[27],
+      },
+      h4: {
+        fontWeight: '600',
+        ...fontSizes[22],
+      },
+      h5: {
+        fontWeight: '600',
+        ...fontSizes[18],
+      },
+      h6: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+    },
+    small: {
+      huge: {
+        fontWeight: '900',
+        ...fontSizes[46],
+      },
+      h1: {
+        fontWeight: '600',
+        ...fontSizes[37],
+      },
+      h2: {
+        fontWeight: '600',
+        ...fontSizes[29],
+      },
+      h3: {
+        fontWeight: '600',
+        ...fontSizes[23],
+      },
+      h4: {
+        fontWeight: '600',
+        ...fontSizes[19],
+      },
+      h5: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+      h6: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+    },
+  },
+  default: {
+    large: {
+      huge: {
+        fontWeight: '900',
+        ...fontSizes[39],
+      },
+      h1: {
+        fontWeight: '600',
+        ...fontSizes[31],
+      },
+      h2: {
+        fontWeight: '600',
+        ...fontSizes[25],
+      },
+      h3: {
+        fontWeight: '600',
+        ...fontSizes[20],
+      },
+      h4: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+      h5: {
+        fontWeight: '600',
+        ...fontSizes[13],
+      },
+      h6: {
+        fontWeight: '600',
+        ...fontSizes[12],
+      },
+    },
+    medium: {
+      huge: {
+        fontWeight: '900',
+        ...fontSizes[34],
+      },
+      h1: {
+        fontWeight: '600',
+        ...fontSizes[27],
+      },
+      h2: {
+        fontWeight: '600',
+        ...fontSizes[22],
+      },
+      h3: {
+        fontWeight: '600',
+        ...fontSizes[18],
+      },
+      h4: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+      h5: {
+        fontWeight: '600',
+        ...fontSizes[13],
+      },
+      h6: {
+        fontWeight: '600',
+        ...fontSizes[12],
+      },
+    },
+    small: {
+      huge: {
+        fontWeight: '900',
+        ...fontSizes[29],
+      },
+      h1: {
+        fontWeight: '600',
+        ...fontSizes[23],
+      },
+      h2: {
+        fontWeight: '600',
+        ...fontSizes[19],
+      },
+      h3: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+      h4: {
+        fontWeight: '600',
+        ...fontSizes[16],
+      },
+      h5: {
+        fontWeight: '600',
+        ...fontSizes[13],
+      },
+      h6: {
+        fontWeight: '600',
+        ...fontSizes[12],
+      },
+    },
+  },
+};
+
+const baseStyle = {
+  fontWeight: '400',
+  ...fontSizes[16],
+};
+
+const body = {
+  headline: {
+    fontWeight: '500',
+    ...fontSizes[16],
+  },
+  paragraph: baseStyle,
+  label: {
+    fontWeight: '500',
+    ...fontSizes[15],
+  },
+  callout: {
+    fontWeight: '400',
+    ...fontSizes[14],
+  },
+  footnote: {
+    fontWeight: '400',
+    ...fontSizes[13],
+  },
+  caption: {
+    fontWeight: '400',
+    ...fontSizes[12],
+  },
+  code: {
+    fontWeight: '400',
+    ...fontSizes[13],
+  },
+};
+
+export const typography = {
+  baseFontSize,
+  headers,
+  body,
+  fontSizes,
+};

--- a/packages/styleguide/src/styles/expo-theme.css
+++ b/packages/styleguide/src/styles/expo-theme.css
@@ -284,7 +284,6 @@
   --expo-theme-palette-white: #ffffff;
   --expo-theme-palette-black: #1b1f23;
   --expo-theme-background-default: var(--expo-color-base-light-white);
-  --expo-theme-background-canvas: var(--expo-color-base-light-gray-000);
   --expo-theme-background-screen: var(--expo-color-base-light-gray-100);
   --expo-theme-background-secondary: var(--expo-color-base-light-gray-100);
   --expo-theme-background-tertiary: var(--expo-color-base-light-gray-200);
@@ -457,7 +456,6 @@
   --expo-theme-palette-white: #ffffff;
   --expo-theme-palette-black: #0d1117;
   --expo-theme-background-default: var(--expo-color-base-dark-gray-100);
-  --expo-theme-background-canvas: var(--expo-color-base-dark-gray-100);
   --expo-theme-background-screen: var(--expo-color-base-dark-gray-000);
   --expo-theme-background-secondary: var(--expo-color-base-dark-gray-200);
   --expo-theme-background-tertiary: var(--expo-color-base-dark-gray-300);

--- a/packages/styleguide/src/styles/themes.ts
+++ b/packages/styleguide/src/styles/themes.ts
@@ -2,7 +2,6 @@ export const theme = {
   background: {
     default: 'var(--expo-theme-background-default)',
     screen: 'var(--expo-theme-background-screen)',
-    canvas: 'var(--expo-theme-background-canvas)',
     secondary: 'var(--expo-theme-background-secondary)',
     tertiary: 'var(--expo-theme-background-tertiary)',
     quaternary: 'var(--expo-theme-background-quaternary)',
@@ -201,7 +200,6 @@ export const theme = {
 export const lightTheme = {
   background: {
     default: 'var(--expo-color-base-light-white)',
-    canvas: 'var(--expo-color-base-light-gray-000)',
     secondary: 'var(--expo-color-base-light-gray-100)',
     tertiary: 'var(--expo-color-base-light-gray-200)',
     quaternary: 'var(--expo-color-base-light-gray-300)',
@@ -280,7 +278,6 @@ export const lightTheme = {
 export const darkTheme = {
   background: {
     default: 'var(--expo-color-base-dark-gray-000)',
-    canvas: 'var(--expo-color-base-dark-gray-100)',
     secondary: 'var(--expo-color-base-dark-gray-200)',
     tertiary: 'var(--expo-color-base-dark-gray-300)',
     quaternary: 'var(--expo-color-base-dark-gray-400)',

--- a/packages/styleguide/src/styles/typography.ts
+++ b/packages/styleguide/src/styles/typography.ts
@@ -149,52 +149,99 @@ const fontSizes = {
 };
 
 const headers = {
-  huge: {
-    fontFamily: fontStacks.black,
-    fontWeight: 900,
-    ...fontSizes[61],
-    [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[53],
-    [`@media (max-width: ${breakpoints.small}px`]: fontSizes[46],
+  xl: {
+    huge: {
+      fontFamily: fontStacks.black,
+      fontWeight: 900,
+      ...fontSizes[61],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[53],
+      [`@media (max-width: ${breakpoints.small}px`]: fontSizes[46],
+    },
+    h1: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[49],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[43],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[37],
+    },
+    h2: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[39],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[34],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[29],
+    },
+    h3: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[31],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[27],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[23],
+    },
+    h4: {
+      fontFamily: fontStacks.medium,
+      fontWeight: 500,
+      ...fontSizes[25],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[22],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[19],
+    },
+    h5: {
+      fontFamily: fontStacks.medium,
+      fontWeight: 500,
+      ...fontSizes[20],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[18],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[16],
+    },
+    h6: {
+      fontFamily: fontStacks.medium,
+      fontWeight: 500,
+      ...fontSizes[16],
+    },
   },
-  h1: {
-    fontFamily: fontStacks.semiBold,
-    fontWeight: 500,
-    ...fontSizes[49],
-    [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[43],
-    [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[37],
-  },
-  h2: {
-    fontFamily: fontStacks.semiBold,
-    fontWeight: 500,
-    ...fontSizes[39],
-    [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[34],
-    [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[29],
-  },
-  h3: {
-    fontFamily: fontStacks.semiBold,
-    fontWeight: 500,
-    ...fontSizes[31],
-    [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[27],
-    [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[23],
-  },
-  h4: {
-    fontFamily: fontStacks.medium,
-    fontWeight: 500,
-    ...fontSizes[25],
-    [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[22],
-    [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[19],
-  },
-  h5: {
-    fontFamily: fontStacks.medium,
-    fontWeight: 500,
-    ...fontSizes[20],
-    [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[18],
-    [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[16],
-  },
-  h6: {
-    fontFamily: fontStacks.medium,
-    fontWeight: 500,
-    ...fontSizes[16],
+  default: {
+    huge: {
+      fontFamily: fontStacks.black,
+      fontWeight: 500,
+      ...fontSizes[39],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[34],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[29],
+    },
+    h1: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[31],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[27],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[23],
+    },
+    h2: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[25],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[22],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[19],
+    },
+    h3: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[20],
+      [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[18],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[16],
+    },
+    h4: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[16],
+    },
+    h5: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[13],
+    },
+    h6: {
+      fontFamily: fontStacks.semiBold,
+      fontWeight: 500,
+      ...fontSizes[12],
+    },
   },
 };
 

--- a/packages/styleguide/src/styles/typography.ts
+++ b/packages/styleguide/src/styles/typography.ts
@@ -155,7 +155,7 @@ const headers = {
       fontWeight: 900,
       ...fontSizes[61],
       [`@media (max-width: ${breakpoints.medium}px)`]: fontSizes[53],
-      [`@media (max-width: ${breakpoints.small}px`]: fontSizes[46],
+      [`@media (max-width: ${breakpoints.small}px)`]: fontSizes[46],
     },
     h1: {
       fontFamily: fontStacks.semiBold,


### PR DESCRIPTION
As we update our docs design, I found that our current header sizes are too large for general-purpose UI. This PR adds "xl" versions of the headers (appropriate for marketing pages) alongside "default" headers (appropriate for prose, general-purpose UI).

Since this is a breaking change, also removed the `canvas` style, since it was deprecated.