### PR TITLE
[native] fix dark mode background.default color

### DIFF
--- a/packages/styleguide-native/src/styles/themes.ts
+++ b/packages/styleguide-native/src/styles/themes.ts
@@ -90,7 +90,7 @@ export const lightTheme = {
 
 export const darkTheme = {
   background: {
-    default: palette.dark.gray['000'],
+    default: palette.dark.gray['100'],
     screen: palette.dark.gray['000'],
     secondary: palette.dark.gray[200],
     tertiary: palette.dark.gray[300],


### PR DESCRIPTION
## Why

The `screen` background color for dark mode on native is the same as the `default` color, which made it impossible to differentiate the base layer and the UI on top of it.

## How

I referenced the web color for `default` to correct this issue.