### PR TITLE
fix: check if localStorage exist before using it

### DIFF
--- a/packages/styleguide/src/components/BlockingSetInitialColorMode.tsx
+++ b/packages/styleguide/src/components/BlockingSetInitialColorMode.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import { isLocalStorageAvailable } from '../utils/helpers';
 
 export function getInitialColorMode(): string | null {
-  const preference = window.localStorage.getItem('data-expo-theme');
-  let hasPreference = typeof preference === 'string';
+  if (isLocalStorageAvailable()) {
+    const preference = window.localStorage.getItem('data-expo-theme');
+    let hasPreference = typeof preference === 'string';
 
-  if (hasPreference) {
-    return preference;
+    if (hasPreference) {
+      return preference;
+    }
   }
 
   const mql = window.matchMedia('(prefers-color-scheme: dark)');

--- a/packages/styleguide/src/components/ThemeProvider.tsx
+++ b/packages/styleguide/src/components/ThemeProvider.tsx
@@ -6,6 +6,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { getInitialColorMode } from './BlockingSetInitialColorMode';
+import { isLocalStorageAvailable } from '../utils/helpers';
 
 export enum Themes {
   AUTO = 'auto',
@@ -42,14 +43,18 @@ export function ThemeProvider(props: ThemeProviderProps) {
     try {
       mediaQuery.addEventListener('change', onThemeChange);
     } catch {
-      // Fallback to old-style listeing for changes, for Safari and IE
+      // Fallback to old-style listening for changes, for Safari and IE
       mediaQuery.addListener(onThemeChange);
     }
 
-    const themePreference = window.localStorage.getItem('data-expo-theme');
+    if (isLocalStorageAvailable()) {
+      const themePreference = window.localStorage.getItem('data-expo-theme');
 
-    if (themePreference === Themes.LIGHT || themePreference === Themes.DARK) {
-      setThemeName(themePreference);
+      if (themePreference === Themes.LIGHT || themePreference === Themes.DARK) {
+        setThemeName(themePreference);
+      } else {
+        setThemeName(Themes.AUTO);
+      }
     } else {
       setThemeName(Themes.AUTO);
     }
@@ -58,7 +63,7 @@ export function ThemeProvider(props: ThemeProviderProps) {
       try {
         mediaQuery.removeEventListener('change', onThemeChange);
       } catch {
-        // Fallback to old-style listeing for changes, for Safari and IE
+        // Fallback to old-style listening for changes, for Safari and IE
         mediaQuery.removeListener(onThemeChange);
       }
     };
@@ -75,34 +80,41 @@ export function ThemeProvider(props: ThemeProviderProps) {
   }
 
   function onThemeChange(event: MediaQueryListEvent | MediaQueryList) {
-    const themePreference = window.localStorage.getItem('data-expo-theme');
+    if (isLocalStorageAvailable()) {
+      const themePreference = window.localStorage.getItem('data-expo-theme');
 
-    if (!themePreference) {
-      if (event.matches) {
-        setDocumentTheme(Themes.DARK);
-      } else {
-        setDocumentTheme(Themes.LIGHT);
+      if (!themePreference) {
+        if (event.matches) {
+          setDocumentTheme(Themes.DARK);
+        } else {
+          setDocumentTheme(Themes.LIGHT);
+        }
       }
+    } else {
+      setDocumentTheme(Themes.AUTO);
     }
   }
 
   function setDarkMode() {
-    (process as any).browser &&
+    if (isLocalStorageAvailable()) {
       window.localStorage.setItem('data-expo-theme', Themes.DARK);
+    }
     setDocumentTheme(Themes.DARK);
     setThemeName(Themes.DARK);
   }
 
   function setLightMode() {
-    (process as any).browser &&
+    if (isLocalStorageAvailable()) {
       window.localStorage.setItem('data-expo-theme', Themes.LIGHT);
+    }
     setDocumentTheme(Themes.LIGHT);
     setThemeName(Themes.LIGHT);
   }
 
   function setAutoMode() {
-    (process as any).browser &&
+    if (isLocalStorageAvailable()) {
       window.localStorage.removeItem('data-expo-theme');
+    }
 
     const themeName = getInitialColorMode() as Themes;
     setDocumentTheme(themeName);

--- a/packages/styleguide/src/utils/helpers.ts
+++ b/packages/styleguide/src/utils/helpers.ts
@@ -1,0 +1,16 @@
+// https://gist.github.com/paulirish/5558557
+export const isLocalStorageAvailable = () => {
+  try {
+    if (!window.localStorage || typeof window.localStorage === 'undefined') {
+      return false;
+    }
+    window.localStorage.setItem('localStorage:test', 'value');
+    if (window.localStorage.getItem('localStorage:test') !== 'value') {
+      return false;
+    }
+    window.localStorage.removeItem('localStorage:test');
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
This is a repost of PR #19 fixing the localStorage issue. It has been reverted because we have experienced an issue with newly published package (it doesn't include new `helpers.js` file), which leads to errors and invalid bechaviour.
 
---

Existence of `localStorage` in the browsers is not guaranteed and currently we have used some basic checks here and there, but not all `localStorage` calls were guarded. This is probably leading to the error flooding Expo's Sentry:

![image](https://user-images.githubusercontent.com/719641/166224759-5a58fca5-2166-4dd7-97b9-f666339be81d.png)

<img width="958" alt="Screenshot 2022-05-02 at 12 31 57" src="https://user-images.githubusercontent.com/719641/166224420-6387f69f-06fe-4c81-8743-9546eb5f3927.png">

This PR adds `isLocalStorageAvailable` helper method copied from the Expo repository (https://github.com/expo/expo/blob/main/docs/common/sentry-utilities.ts#L65) and wraps all existing localStorage calls within the codebase also adding fallbacks.

I have also fixed few typos which I have encountered in the comments. 🙂 