### PR TITLE
feat: add info styles for convenience

### DIFF
--- a/packages/styleguide-native/src/styles/themes.ts
+++ b/packages/styleguide-native/src/styles/themes.ts
@@ -10,6 +10,7 @@ export const lightTheme = {
     error: palette.light.red[100],
     warning: palette.light.yellow[100],
     success: palette.light.green[100],
+    info: palette.light.blue[100],
     overlay: palette.light.white,
   },
   border: {
@@ -17,6 +18,7 @@ export const lightTheme = {
     error: palette.light.red[300],
     success: palette.light.green[300],
     warning: palette.light.yellow[300],
+    info: palette.light.blue[300],
   },
   button: {
     primary: {
@@ -61,6 +63,7 @@ export const lightTheme = {
     error: palette.light.red[600],
     warning: palette.light.yellow[900],
     success: palette.light.green[600],
+    info: palette.light.blue[600],
   },
   code: {
     keyword: palette.light.blue[500],
@@ -90,7 +93,7 @@ export const lightTheme = {
 
 export const darkTheme = {
   background: {
-    default: palette.dark.gray['100'],
+    default: palette.dark.gray[100],
     screen: palette.dark.gray['000'],
     secondary: palette.dark.gray[200],
     tertiary: palette.dark.gray[300],
@@ -98,6 +101,7 @@ export const darkTheme = {
     error: palette.dark.red['000'],
     warning: palette.dark.yellow['000'],
     success: palette.dark.green['000'],
+    info: palette.dark.blue['000'],
     overlay: palette.dark.gray[200],
   },
   border: {
@@ -105,6 +109,7 @@ export const darkTheme = {
     error: palette.dark.red[200],
     success: palette.dark.green[200],
     warning: palette.dark.yellow[200],
+    info: palette.dark.blue[200],
   },
   button: {
     primary: {
@@ -149,6 +154,7 @@ export const darkTheme = {
     error: palette.dark.red[600],
     warning: palette.dark.yellow[900],
     success: palette.dark.green[600],
+    info: palette.dark.blue[700],
   },
   code: {
     keyword: palette.dark.blue[600],

--- a/packages/styleguide/src/styles/expo-theme.css
+++ b/packages/styleguide/src/styles/expo-theme.css
@@ -291,11 +291,13 @@
   --expo-theme-background-error: var(--expo-color-base-light-red-100);
   --expo-theme-background-warning: var(--expo-color-base-light-yellow-100);
   --expo-theme-background-success: var(--expo-color-base-light-green-100);
+  --expo-theme-background-info: var(--expo-color-base-light-blue-100);
   --expo-theme-background-overlay: var(--expo-color-base-light-white);
   --expo-theme-border-default: var(--expo-color-base-light-gray-300);
   --expo-theme-border-error: var(--expo-color-base-light-red-300);
   --expo-theme-border-warning: var(--expo-color-base-light-yellow-300);
   --expo-theme-border-success: var(--expo-color-base-light-green-300);
+  --expo-theme-border-info: var(--expo-color-base-light-blue-300);
   --expo-theme-button-primary-background: var(
     --expo-color-base-light-primary-500
   );
@@ -332,6 +334,7 @@
   --expo-theme-text-error: var(--expo-color-base-light-red-600);
   --expo-theme-text-warning: var(--expo-color-base-light-yellow-900);
   --expo-theme-text-success: var(--expo-color-base-light-green-700);
+  --expo-theme-text-info: var(--expo-color-base-light-blue-600);
   --expo-theme-code-keyword: var(--expo-color-base-light-blue-500);
   --expo-theme-code-builtin: var(--expo-color-base-light-green-600);
   --expo-theme-code-property: var(--expo-color-base-light-red-500);
@@ -469,11 +472,13 @@
   --expo-theme-background-error: var(--expo-color-base-dark-red-000);
   --expo-theme-background-warning: var(--expo-color-base-dark-yellow-000);
   --expo-theme-background-success: var(--expo-color-base-dark-green-000);
+  --expo-theme-background-info: var(--expo-color-base-dark-blue-000);
   --expo-theme-background-overlay: var(--expo-color-base-dark-gray-200);
   --expo-theme-border-default: var(--expo-color-base-dark-gray-400);
   --expo-theme-border-error: var(--expo-color-base-dark-red-200);
   --expo-theme-border-warning: var(--expo-color-base-dark-yellow-300);
   --expo-theme-border-success: var(--expo-color-base-dark-green-200);
+  --expo-theme-border-info: var(--expo-color-base-dark-blue-200);
   --expo-theme-button-primary-background: var(
     --expo-color-base-dark-primary-500
   );
@@ -508,6 +513,7 @@
   --expo-theme-text-error: var(--expo-color-base-dark-red-600);
   --expo-theme-text-warning: var(--expo-color-base-dark-yellow-900);
   --expo-theme-text-success: var(--expo-color-base-dark-green-700);
+  --expo-theme-text-info: var(--expo-color-base-dark-blue-700);
   --expo-theme-code-keyword: var(--expo-color-base-dark-blue-600);
   --expo-theme-code-builtin: var(--expo-color-base-dark-green-600);
   --expo-theme-code-property: var(--expo-color-base-dark-red-600);

--- a/packages/styleguide/src/styles/themes.ts
+++ b/packages/styleguide/src/styles/themes.ts
@@ -8,6 +8,7 @@ export const theme = {
     error: 'var(--expo-theme-background-error)',
     warning: 'var(--expo-theme-background-warning)',
     success: 'var(--expo-theme-background-success)',
+    info: 'var(--expo-theme-background-info)',
     overlay: 'var(--expo-theme-background-overlay)',
   },
   border: {
@@ -15,6 +16,7 @@ export const theme = {
     error: 'var(--expo-theme-border-error)',
     warning: 'var(--expo-theme-border-warning)',
     success: 'var(--expo-theme-border-success)',
+    info: 'var(--expo-theme-border-info)',
   },
   button: {
     primary: {
@@ -53,6 +55,7 @@ export const theme = {
     error: 'var(--expo-theme-text-error)',
     warning: 'var(--expo-theme-text-warning)',
     success: 'var(--expo-theme-text-success)',
+    info: 'var(--expo-theme-text-info)',
   },
   icon: {
     default: 'var(--expo-theme-icon-default)',
@@ -206,6 +209,7 @@ export const lightTheme = {
     error: 'var(--expo-color-base-light-red-100)',
     warning: 'var(--expo-color-base-light-yellow-100)',
     success: 'var(--expo-color-base-light-green-100)',
+    info: 'var(--expo-color-base-light-blue-100)',
     overlay: 'var(--expo-color-base-light-white)',
   },
   border: {
@@ -213,6 +217,7 @@ export const lightTheme = {
     error: 'var(--expo-color-base-light-red-300)',
     success: 'var(--expo-color-base-light-green-300)',
     warning: 'var(--expo-color-base-light-yellow-300)',
+    info: 'var(--expo-color-base-light-blue-300)',
   },
   button: {
     primary: {
@@ -257,6 +262,7 @@ export const lightTheme = {
     error: 'var(--expo-color-base-light-red-600)',
     warning: 'var(--expo-color-base-light-yellow-900)',
     success: 'var(--expo-color-base-light-green-600)',
+    info: 'var(--expo-color-base-light-green-700)',
   },
   code: {
     keyword: 'var(--expo-color-base-light-blue-500)',
@@ -284,6 +290,7 @@ export const darkTheme = {
     error: 'var(--expo-color-base-dark-red-000)',
     warning: 'var(--expo-color-base-dark-yellow-000)',
     success: 'var(--expo-color-base-dark-green-000)',
+    info: 'var(--expo-color-base-dark-blue-000)',
     overlay: 'var(--expo-color-base-dark-gray-100)',
   },
   border: {
@@ -291,6 +298,7 @@ export const darkTheme = {
     error: 'var(--expo-color-base-dark-red-200)',
     success: 'var(--expo-color-base-dark-green-200)',
     warning: 'var(--expo-color-base-dark-yellow-200)',
+    info: 'var(--expo-color-base-dark-blue-200)',
   },
   button: {
     primary: {
@@ -335,6 +343,7 @@ export const darkTheme = {
     error: 'var(--expo-color-base-dark-red-600)',
     warning: 'var(--expo-color-base-dark-yellow-900)',
     success: 'var(--expo-color-base-dark-green-600)',
+    info: 'var(--expo-color-base-dark-blue-600)',
   },
   code: {
     keyword: 'var(--expo-color-base-dark-blue-600)',


### PR DESCRIPTION
# Why

While working on latest design updates in universe website and docs, I have spotted that Styleguide misses the "info" (blue) style while offering one for "error" (red), "warning" (yellow) and "success" (green). 

Those aliases are handy to use, and working with them is more pleasant than working with palette directly, so I have decided to add "info" to the exiting options.

# How

This PR adds the "info" variable and aliases for both `styleguide` and `styleguide-native`. The values are based on the blue Home tile with small tweaks. I have tested them locally using palette values directly (separate for each theme).

Feel free to suggest any color alteration, I have no strong preferences on the selected shades.

# Preview

<img width="231" align="left" alt="Screenshot 2022-07-08 at 16 04 23" src="https://user-images.githubusercontent.com/719641/178007774-6ad5507b-f8f1-4784-b393-b3e6cee2594f.png">
<img width="231" alt="Screenshot 2022-07-08 at 16 03 47" src="https://user-images.githubusercontent.com/719641/178007779-627e8ac3-a074-4b26-ac89-bbfea3e96c38.png">

