### PR TITLE
[styleguide] export `IconProps` in the main index file

### DIFF
--- a/packages/styleguide/src/index.ts
+++ b/packages/styleguide/src/index.ts
@@ -8,6 +8,7 @@ import { ThemeProvider, useTheme } from './components/ThemeProvider';
 import { spacing } from './styles/spacing';
 import { breakpoints } from './styles/breakpoints';
 import { typography } from './styles/typography';
+import { IconProps } from 'types';
 
 export * from './icons';
 export * from './logos';
@@ -26,4 +27,5 @@ export {
   ThemeProvider,
   typography,
   useTheme,
+  IconProps
 };


### PR DESCRIPTION
# Why

Currently the only way to use `IconProps` in other project is to directly import them from `dist` directory:
* https://github.com/expo/universe/pull/10111/files#diff-e933dd581115897d7c620afde3c2ef0cb037f05bc0b1c31cadc2caf5859e85d3R3

# How

This small PR adds an export for the `IconProps` in the main package file.