### PR TITLE
[styleguide-native] simplify icon props, export `IconProps` type

### DIFF
--- a/packages/styleguide-native/src/icons/ActivityIcon.tsx
+++ b/packages/styleguide-native/src/icons/ActivityIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ActivityIcon(props: SvgProps & IconProps) {
+export default function ActivityIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/AddPhotoIcon.tsx
+++ b/packages/styleguide-native/src/icons/AddPhotoIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function AddPhotoIcon(props: SvgProps & IconProps) {
+export default function AddPhotoIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/AndroidIcon.tsx
+++ b/packages/styleguide-native/src/icons/AndroidIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function AndroidIcon(props: SvgProps & IconProps) {
+export default function AndroidIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/AppleAppStoreIcon.tsx
+++ b/packages/styleguide-native/src/icons/AppleAppStoreIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function AppleAppStoreIcon(props: SvgProps & IconProps) {
+export default function AppleAppStoreIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/AppleIcon.tsx
+++ b/packages/styleguide-native/src/icons/AppleIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function AppleIcon(props: SvgProps & IconProps) {
+export default function AppleIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/AppleSimulatorIcon.tsx
+++ b/packages/styleguide-native/src/icons/AppleSimulatorIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Rect, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Rect } from "react-native-svg";
 import { IconProps } from "../types";
-export default function AppleSimulatorIcon(props: SvgProps & IconProps) {
+export default function AppleSimulatorIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ArrowDownIcon.tsx
+++ b/packages/styleguide-native/src/icons/ArrowDownIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ArrowDownIcon(props: SvgProps & IconProps) {
+export default function ArrowDownIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ArrowLeftIcon.tsx
+++ b/packages/styleguide-native/src/icons/ArrowLeftIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ArrowLeftIcon(props: SvgProps & IconProps) {
+export default function ArrowLeftIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ArrowRightIcon.tsx
+++ b/packages/styleguide-native/src/icons/ArrowRightIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ArrowRightIcon(props: SvgProps & IconProps) {
+export default function ArrowRightIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ArrowUpIcon.tsx
+++ b/packages/styleguide-native/src/icons/ArrowUpIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ArrowUpIcon(props: SvgProps & IconProps) {
+export default function ArrowUpIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ArrowUpRightIcon.tsx
+++ b/packages/styleguide-native/src/icons/ArrowUpRightIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ArrowUpRightIcon(props: SvgProps & IconProps) {
+export default function ArrowUpRightIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/AtSignIcon.tsx
+++ b/packages/styleguide-native/src/icons/AtSignIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function AtSignIcon(props: SvgProps & IconProps) {
+export default function AtSignIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BadgeIcon.tsx
+++ b/packages/styleguide-native/src/icons/BadgeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BadgeIcon(props: SvgProps & IconProps) {
+export default function BadgeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BellIcon.tsx
+++ b/packages/styleguide-native/src/icons/BellIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BellIcon(props: SvgProps & IconProps) {
+export default function BellIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BranchIcon.tsx
+++ b/packages/styleguide-native/src/icons/BranchIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BranchIcon(props: SvgProps & IconProps) {
+export default function BranchIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BugInspectIcon.tsx
+++ b/packages/styleguide-native/src/icons/BugInspectIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BugInspectIcon(props: SvgProps & IconProps) {
+export default function BugInspectIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BuildIcon.tsx
+++ b/packages/styleguide-native/src/icons/BuildIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BuildIcon(props: SvgProps & IconProps) {
+export default function BuildIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BuildNumberIcon.tsx
+++ b/packages/styleguide-native/src/icons/BuildNumberIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BuildNumberIcon(props: SvgProps & IconProps) {
+export default function BuildNumberIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/BuildProfileIcon.tsx
+++ b/packages/styleguide-native/src/icons/BuildProfileIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function BuildProfileIcon(props: SvgProps & IconProps) {
+export default function BuildProfileIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ChannelIcon.tsx
+++ b/packages/styleguide-native/src/icons/ChannelIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ChannelIcon(props: SvgProps & IconProps) {
+export default function ChannelIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ChartIcon.tsx
+++ b/packages/styleguide-native/src/icons/ChartIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ChartIcon(props: SvgProps & IconProps) {
+export default function ChartIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/CheckIcon.tsx
+++ b/packages/styleguide-native/src/icons/CheckIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function CheckIcon(props: SvgProps & IconProps) {
+export default function CheckIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ChevronDownIcon.tsx
+++ b/packages/styleguide-native/src/icons/ChevronDownIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ChevronDownIcon(props: SvgProps & IconProps) {
+export default function ChevronDownIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ChevronLeftIcon.tsx
+++ b/packages/styleguide-native/src/icons/ChevronLeftIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ChevronLeftIcon(props: SvgProps & IconProps) {
+export default function ChevronLeftIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ChevronRightIcon.tsx
+++ b/packages/styleguide-native/src/icons/ChevronRightIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ChevronRightIcon(props: SvgProps & IconProps) {
+export default function ChevronRightIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ChevronUpIcon.tsx
+++ b/packages/styleguide-native/src/icons/ChevronUpIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ChevronUpIcon(props: SvgProps & IconProps) {
+export default function ChevronUpIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ClipboardIcon.tsx
+++ b/packages/styleguide-native/src/icons/ClipboardIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ClipboardIcon(props: SvgProps & IconProps) {
+export default function ClipboardIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/CloudSlashIcon.tsx
+++ b/packages/styleguide-native/src/icons/CloudSlashIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function CloudSlashIcon(props: SvgProps & IconProps) {
+export default function CloudSlashIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/CodeIcon.tsx
+++ b/packages/styleguide-native/src/icons/CodeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function CodeIcon(props: SvgProps & IconProps) {
+export default function CodeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/CommitIcon.tsx
+++ b/packages/styleguide-native/src/icons/CommitIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function CommitIcon(props: SvgProps & IconProps) {
+export default function CommitIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/CredentialIcon.tsx
+++ b/packages/styleguide-native/src/icons/CredentialIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path, Circle } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Circle } from "react-native-svg";
 import { IconProps } from "../types";
-export default function CredentialIcon(props: SvgProps & IconProps) {
+export default function CredentialIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/CreditCardIcon.tsx
+++ b/packages/styleguide-native/src/icons/CreditCardIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function CreditCardIcon(props: SvgProps & IconProps) {
+export default function CreditCardIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/DebugIcon.tsx
+++ b/packages/styleguide-native/src/icons/DebugIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DebugIcon(props: SvgProps & IconProps) {
+export default function DebugIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/DeploymentIcon.tsx
+++ b/packages/styleguide-native/src/icons/DeploymentIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DeploymentIcon(props: SvgProps & IconProps) {
+export default function DeploymentIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/DeploymentsIcon.tsx
+++ b/packages/styleguide-native/src/icons/DeploymentsIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path, Ellipse } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Ellipse } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DeploymentsIcon(props: SvgProps & IconProps) {
+export default function DeploymentsIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/DiscordIcon.tsx
+++ b/packages/styleguide-native/src/icons/DiscordIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DiscordIcon(props: SvgProps & IconProps) {
+export default function DiscordIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/DiscourseIcon.tsx
+++ b/packages/styleguide-native/src/icons/DiscourseIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DiscourseIcon(props: SvgProps & IconProps) {
+export default function DiscourseIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/DownloadIcon.tsx
+++ b/packages/styleguide-native/src/icons/DownloadIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DownloadIcon(props: SvgProps & IconProps) {
+export default function DownloadIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ErrorIcon.tsx
+++ b/packages/styleguide-native/src/icons/ErrorIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ErrorIcon(props: SvgProps & IconProps) {
+export default function ErrorIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/FacebookIcon.tsx
+++ b/packages/styleguide-native/src/icons/FacebookIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function FacebookIcon(props: SvgProps & IconProps) {
+export default function FacebookIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/GeneralIcon.tsx
+++ b/packages/styleguide-native/src/icons/GeneralIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Mask, Rect } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Mask, Rect } from "react-native-svg";
 import { IconProps } from "../types";
-export default function GeneralIcon(props: SvgProps & IconProps) {
+export default function GeneralIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/GithubIcon.tsx
+++ b/packages/styleguide-native/src/icons/GithubIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function GithubIcon(props: SvgProps & IconProps) {
+export default function GithubIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/GoogleAppStoreIcon.tsx
+++ b/packages/styleguide-native/src/icons/GoogleAppStoreIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function GoogleAppStoreIcon(props: SvgProps & IconProps) {
+export default function GoogleAppStoreIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/HamburgerIcon.tsx
+++ b/packages/styleguide-native/src/icons/HamburgerIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function HamburgerIcon(props: SvgProps & IconProps) {
+export default function HamburgerIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/HeadsetIcon.tsx
+++ b/packages/styleguide-native/src/icons/HeadsetIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function HeadsetIcon(props: SvgProps & IconProps) {
+export default function HeadsetIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/HomeFilledIcon.tsx
+++ b/packages/styleguide-native/src/icons/HomeFilledIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function HomeFilledIcon(props: SvgProps & IconProps) {
+export default function HomeFilledIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/HomeIcon.tsx
+++ b/packages/styleguide-native/src/icons/HomeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function HomeIcon(props: SvgProps & IconProps) {
+export default function HomeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/InfoIcon.tsx
+++ b/packages/styleguide-native/src/icons/InfoIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function InfoIcon(props: SvgProps & IconProps) {
+export default function InfoIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/InspectElementIcon.tsx
+++ b/packages/styleguide-native/src/icons/InspectElementIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function InspectElementIcon(props: SvgProps & IconProps) {
+export default function InspectElementIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/InstagramIcon.tsx
+++ b/packages/styleguide-native/src/icons/InstagramIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function InstagramIcon(props: SvgProps & IconProps) {
+export default function InstagramIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/InvoicesIcon.tsx
+++ b/packages/styleguide-native/src/icons/InvoicesIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function InvoicesIcon(props: SvgProps & IconProps) {
+export default function InvoicesIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/LifebuoyIcon.tsx
+++ b/packages/styleguide-native/src/icons/LifebuoyIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function LifebuoyIcon(props: SvgProps & IconProps) {
+export default function LifebuoyIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/LockIcon.tsx
+++ b/packages/styleguide-native/src/icons/LockIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function LockIcon(props: SvgProps & IconProps) {
+export default function LockIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/LogoutMobileIcon.tsx
+++ b/packages/styleguide-native/src/icons/LogoutMobileIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function LogoutMobileIcon(props: SvgProps & IconProps) {
+export default function LogoutMobileIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/LogsIcon.tsx
+++ b/packages/styleguide-native/src/icons/LogsIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function LogsIcon(props: SvgProps & IconProps) {
+export default function LogsIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/MailIcon.tsx
+++ b/packages/styleguide-native/src/icons/MailIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function MailIcon(props: SvgProps & IconProps) {
+export default function MailIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/MegaphoneIcon.tsx
+++ b/packages/styleguide-native/src/icons/MegaphoneIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function MegaphoneIcon(props: SvgProps & IconProps) {
+export default function MegaphoneIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/MessageIcon.tsx
+++ b/packages/styleguide-native/src/icons/MessageIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function MessageIcon(props: SvgProps & IconProps) {
+export default function MessageIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/OneTimePasswordIcon.tsx
+++ b/packages/styleguide-native/src/icons/OneTimePasswordIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path, Rect } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Rect } from "react-native-svg";
 import { IconProps } from "../types";
-export default function OneTimePasswordIcon(props: SvgProps & IconProps) {
+export default function OneTimePasswordIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/OpenInternalIcon.tsx
+++ b/packages/styleguide-native/src/icons/OpenInternalIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function OpenInternalIcon(props: SvgProps & IconProps) {
+export default function OpenInternalIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/OverviewIcon.tsx
+++ b/packages/styleguide-native/src/icons/OverviewIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function OverviewIcon(props: SvgProps & IconProps) {
+export default function OverviewIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PerformanceIcon.tsx
+++ b/packages/styleguide-native/src/icons/PerformanceIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PerformanceIcon(props: SvgProps & IconProps) {
+export default function PerformanceIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PersonalTrainerIcon.tsx
+++ b/packages/styleguide-native/src/icons/PersonalTrainerIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PersonalTrainerIcon(props: SvgProps & IconProps) {
+export default function PersonalTrainerIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PinIcon.tsx
+++ b/packages/styleguide-native/src/icons/PinIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PinIcon(props: SvgProps & IconProps) {
+export default function PinIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PlanEnterpriseIcon.tsx
+++ b/packages/styleguide-native/src/icons/PlanEnterpriseIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PlanEnterpriseIcon(props: SvgProps & IconProps) {
+export default function PlanEnterpriseIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PlanFreeIcon.tsx
+++ b/packages/styleguide-native/src/icons/PlanFreeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PlanFreeIcon(props: SvgProps & IconProps) {
+export default function PlanFreeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PlanProductionIcon.tsx
+++ b/packages/styleguide-native/src/icons/PlanProductionIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PlanProductionIcon(props: SvgProps & IconProps) {
+export default function PlanProductionIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PlansIcon.tsx
+++ b/packages/styleguide-native/src/icons/PlansIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path, Rect } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Rect } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PlansIcon(props: SvgProps & IconProps) {
+export default function PlansIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PlusIcon.tsx
+++ b/packages/styleguide-native/src/icons/PlusIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PlusIcon(props: SvgProps & IconProps) {
+export default function PlusIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PrivacyIcon.tsx
+++ b/packages/styleguide-native/src/icons/PrivacyIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PrivacyIcon(props: SvgProps & IconProps) {
+export default function PrivacyIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ProjectTransferIcon.tsx
+++ b/packages/styleguide-native/src/icons/ProjectTransferIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ProjectTransferIcon(props: SvgProps & IconProps) {
+export default function ProjectTransferIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/PushToDeviceIcon.tsx
+++ b/packages/styleguide-native/src/icons/PushToDeviceIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path, Rect } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Rect } from "react-native-svg";
 import { IconProps } from "../types";
-export default function PushToDeviceIcon(props: SvgProps & IconProps) {
+export default function PushToDeviceIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/QrCodeIcon.tsx
+++ b/packages/styleguide-native/src/icons/QrCodeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function QrCodeIcon(props: SvgProps & IconProps) {
+export default function QrCodeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/QuestionIcon.tsx
+++ b/packages/styleguide-native/src/icons/QuestionIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function QuestionIcon(props: SvgProps & IconProps) {
+export default function QuestionIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/QuestionMarkIcon.tsx
+++ b/packages/styleguide-native/src/icons/QuestionMarkIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function QuestionMarkIcon(props: SvgProps & IconProps) {
+export default function QuestionMarkIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/RedditIcon.tsx
+++ b/packages/styleguide-native/src/icons/RedditIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function RedditIcon(props: SvgProps & IconProps) {
+export default function RedditIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/RefreshIcon.tsx
+++ b/packages/styleguide-native/src/icons/RefreshIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function RefreshIcon(props: SvgProps & IconProps) {
+export default function RefreshIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/RolloutIcon.tsx
+++ b/packages/styleguide-native/src/icons/RolloutIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path, Circle } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Circle } from "react-native-svg";
 import { IconProps } from "../types";
-export default function RolloutIcon(props: SvgProps & IconProps) {
+export default function RolloutIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/RunIcon.tsx
+++ b/packages/styleguide-native/src/icons/RunIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function RunIcon(props: SvgProps & IconProps) {
+export default function RunIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/RuntimeVersionIcon.tsx
+++ b/packages/styleguide-native/src/icons/RuntimeVersionIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function RuntimeVersionIcon(props: SvgProps & IconProps) {
+export default function RuntimeVersionIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ScanIcon.tsx
+++ b/packages/styleguide-native/src/icons/ScanIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ScanIcon(props: SvgProps & IconProps) {
+export default function ScanIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/SearchIcon.tsx
+++ b/packages/styleguide-native/src/icons/SearchIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Circle, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Circle } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SearchIcon(props: SvgProps & IconProps) {
+export default function SearchIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/SecretsIcon.tsx
+++ b/packages/styleguide-native/src/icons/SecretsIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SecretsIcon(props: SvgProps & IconProps) {
+export default function SecretsIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/SettingsFilledIcon.tsx
+++ b/packages/styleguide-native/src/icons/SettingsFilledIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SettingsFilledIcon(props: SvgProps & IconProps) {
+export default function SettingsFilledIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/SettingsIcon.tsx
+++ b/packages/styleguide-native/src/icons/SettingsIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SettingsIcon(props: SvgProps & IconProps) {
+export default function SettingsIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/SlashShortcutIcon.tsx
+++ b/packages/styleguide-native/src/icons/SlashShortcutIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SlashShortcutIcon(props: SvgProps & IconProps) {
+export default function SlashShortcutIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/SparklesIcon.tsx
+++ b/packages/styleguide-native/src/icons/SparklesIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SparklesIcon(props: SvgProps & IconProps) {
+export default function SparklesIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/StatusCanceledIcon.tsx
+++ b/packages/styleguide-native/src/icons/StatusCanceledIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function StatusCanceledIcon(props: SvgProps & IconProps) {
+export default function StatusCanceledIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/StatusFailedIcon.tsx
+++ b/packages/styleguide-native/src/icons/StatusFailedIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function StatusFailedIcon(props: SvgProps & IconProps) {
+export default function StatusFailedIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/StatusNewIcon.tsx
+++ b/packages/styleguide-native/src/icons/StatusNewIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function StatusNewIcon(props: SvgProps & IconProps) {
+export default function StatusNewIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/StatusSuccessIcon.tsx
+++ b/packages/styleguide-native/src/icons/StatusSuccessIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function StatusSuccessIcon(props: SvgProps & IconProps) {
+export default function StatusSuccessIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/StatusWaitingIcon.tsx
+++ b/packages/styleguide-native/src/icons/StatusWaitingIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function StatusWaitingIcon(props: SvgProps & IconProps) {
+export default function StatusWaitingIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/StoreIcon.tsx
+++ b/packages/styleguide-native/src/icons/StoreIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function StoreIcon(props: SvgProps & IconProps) {
+export default function StoreIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ThemeAutoIcon.tsx
+++ b/packages/styleguide-native/src/icons/ThemeAutoIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Circle, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Circle } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ThemeAutoIcon(props: SvgProps & IconProps) {
+export default function ThemeAutoIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ThemeDarkIcon.tsx
+++ b/packages/styleguide-native/src/icons/ThemeDarkIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ThemeDarkIcon(props: SvgProps & IconProps) {
+export default function ThemeDarkIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ThemeIcon.tsx
+++ b/packages/styleguide-native/src/icons/ThemeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ThemeIcon(props: SvgProps & IconProps) {
+export default function ThemeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ThemeLightIcon.tsx
+++ b/packages/styleguide-native/src/icons/ThemeLightIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ThemeLightIcon(props: SvgProps & IconProps) {
+export default function ThemeLightIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ThumbsDownIcon.tsx
+++ b/packages/styleguide-native/src/icons/ThumbsDownIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ThumbsDownIcon(props: SvgProps & IconProps) {
+export default function ThumbsDownIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/ThumbsUpIcon.tsx
+++ b/packages/styleguide-native/src/icons/ThumbsUpIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ThumbsUpIcon(props: SvgProps & IconProps) {
+export default function ThumbsUpIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TokensIcon.tsx
+++ b/packages/styleguide-native/src/icons/TokensIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Circle, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path, Circle } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TokensIcon(props: SvgProps & IconProps) {
+export default function TokensIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TrashIcon.tsx
+++ b/packages/styleguide-native/src/icons/TrashIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TrashIcon(props: SvgProps & IconProps) {
+export default function TrashIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TriangleDownIcon.tsx
+++ b/packages/styleguide-native/src/icons/TriangleDownIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TriangleDownIcon(props: SvgProps & IconProps) {
+export default function TriangleDownIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TriangleLeftIcon.tsx
+++ b/packages/styleguide-native/src/icons/TriangleLeftIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TriangleLeftIcon(props: SvgProps & IconProps) {
+export default function TriangleLeftIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TriangleRightIcon.tsx
+++ b/packages/styleguide-native/src/icons/TriangleRightIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TriangleRightIcon(props: SvgProps & IconProps) {
+export default function TriangleRightIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TriangleUpIcon.tsx
+++ b/packages/styleguide-native/src/icons/TriangleUpIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TriangleUpIcon(props: SvgProps & IconProps) {
+export default function TriangleUpIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TwitchIcon.tsx
+++ b/packages/styleguide-native/src/icons/TwitchIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TwitchIcon(props: SvgProps & IconProps) {
+export default function TwitchIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/TwitterIcon.tsx
+++ b/packages/styleguide-native/src/icons/TwitterIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function TwitterIcon(props: SvgProps & IconProps) {
+export default function TwitterIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UndoIcon.tsx
+++ b/packages/styleguide-native/src/icons/UndoIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UndoIcon(props: SvgProps & IconProps) {
+export default function UndoIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UpdateIcon.tsx
+++ b/packages/styleguide-native/src/icons/UpdateIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UpdateIcon(props: SvgProps & IconProps) {
+export default function UpdateIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UpgradeIcon.tsx
+++ b/packages/styleguide-native/src/icons/UpgradeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UpgradeIcon(props: SvgProps & IconProps) {
+export default function UpgradeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UploadIcon.tsx
+++ b/packages/styleguide-native/src/icons/UploadIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UploadIcon(props: SvgProps & IconProps) {
+export default function UploadIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UserFilledIcon.tsx
+++ b/packages/styleguide-native/src/icons/UserFilledIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UserFilledIcon(props: SvgProps & IconProps) {
+export default function UserFilledIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UserIcon.tsx
+++ b/packages/styleguide-native/src/icons/UserIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UserIcon(props: SvgProps & IconProps) {
+export default function UserIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UsersFilledIcon.tsx
+++ b/packages/styleguide-native/src/icons/UsersFilledIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UsersFilledIcon(props: SvgProps & IconProps) {
+export default function UsersFilledIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/UsersIcon.tsx
+++ b/packages/styleguide-native/src/icons/UsersIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function UsersIcon(props: SvgProps & IconProps) {
+export default function UsersIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/VersionIcon.tsx
+++ b/packages/styleguide-native/src/icons/VersionIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function VersionIcon(props: SvgProps & IconProps) {
+export default function VersionIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/WarningIcon.tsx
+++ b/packages/styleguide-native/src/icons/WarningIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function WarningIcon(props: SvgProps & IconProps) {
+export default function WarningIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/XIcon.tsx
+++ b/packages/styleguide-native/src/icons/XIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function XIcon(props: SvgProps & IconProps) {
+export default function XIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/icons/YoutubeIcon.tsx
+++ b/packages/styleguide-native/src/icons/YoutubeIcon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function YoutubeIcon(props: SvgProps & IconProps) {
+export default function YoutubeIcon(props: IconProps) {
   const { size, color, width, height } = props;
   return (
     <Svg

--- a/packages/styleguide-native/src/index.ts
+++ b/packages/styleguide-native/src/index.ts
@@ -5,6 +5,7 @@ import { iconSize, borderRadius } from './styles/sizing';
 import { spacing } from './styles/spacing';
 import { breakpoints } from './styles/breakpoints';
 import { typography } from './styles/typography';
+import { IconProps } from 'types';
 
 export * from './icons';
 export * from './logos';
@@ -18,4 +19,5 @@ export {
   shadows,
   spacing,
   typography,
+  IconProps,
 };

--- a/packages/styleguide-native/src/logos/DocsLogo.tsx
+++ b/packages/styleguide-native/src/logos/DocsLogo.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function DocsLogo(props: SvgProps & IconProps) {
+export default function DocsLogo(props: IconProps) {
   const { color } = props;
   return (
     <Svg viewBox="0 0 20 20" fill="none" {...props}>

--- a/packages/styleguide-native/src/logos/ExpoGoLogo.tsx
+++ b/packages/styleguide-native/src/logos/ExpoGoLogo.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function ExpoGoLogo(props: SvgProps & IconProps) {
+export default function ExpoGoLogo(props: IconProps) {
   const { color } = props;
   return (
     <Svg viewBox="0 0 20 20" fill="none" {...props}>

--- a/packages/styleguide-native/src/logos/Logo.tsx
+++ b/packages/styleguide-native/src/logos/Logo.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function Logo(props: SvgProps & IconProps) {
+export default function Logo(props: IconProps) {
   const { color } = props;
   return (
     <Svg viewBox="0 0 20 20" fill="none" {...props}>

--- a/packages/styleguide-native/src/logos/SnackLogo.tsx
+++ b/packages/styleguide-native/src/logos/SnackLogo.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function SnackLogo(props: SvgProps & IconProps) {
+export default function SnackLogo(props: IconProps) {
   const { color } = props;
   return (
     <Svg viewBox="0 0 20 20" fill="none" {...props}>

--- a/packages/styleguide-native/src/logos/WordMarkLogo.tsx
+++ b/packages/styleguide-native/src/logos/WordMarkLogo.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import Svg, { SvgProps, Path } from "react-native-svg";
+import React from "react";
+import Svg, { Path } from "react-native-svg";
 import { IconProps } from "../types";
-export default function WordMarkLogo(props: SvgProps & IconProps) {
+export default function WordMarkLogo(props: IconProps) {
   const { color } = props;
   return (
     <Svg viewBox="0 0 71 20" fill="none" {...props}>

--- a/packages/styleguide-native/src/types/index.ts
+++ b/packages/styleguide-native/src/types/index.ts
@@ -1,3 +1,5 @@
-export type IconProps = {
+import { SvgProps } from "react-native-svg";
+
+export type IconProps = SvgProps & {
   size?: number;
 };

--- a/packages/styleguide-native/svgr-icon-template.js
+++ b/packages/styleguide-native/svgr-icon-template.js
@@ -1,14 +1,15 @@
 function iconTemplate(api, opts, rest) {
-  const { jsx, imports } = rest;
+  const { jsx } = rest;
   const template = api.template.smart({ plugins: ['typescript'] });
   const { componentName } = opts.state;
   const exportName = componentName.replace('Svg', '');
 
   return template.ast`
-    ${imports}
+    import React from 'react';
+    import Svg, { Path } from 'react-native-svg';
     import { IconProps } from '../types';
 
-    export default function ${exportName}(props: SvgProps & IconProps) {
+    export default function ${exportName}(props: IconProps) {
       const { size, color, width, height } = props;
 
       return ${jsx};

--- a/packages/styleguide-native/svgr-logo-template.js
+++ b/packages/styleguide-native/svgr-logo-template.js
@@ -1,14 +1,15 @@
 function iconTemplate(api, opts, rest) {
-  const { jsx, imports } = rest;
+  const { jsx } = rest;
   const template = api.template.smart({ plugins: ['typescript'] });
   const { componentName } = opts.state;
   const exportName = componentName.replace('Svg', '');
 
   return template.ast`
-    ${imports}
+    import React from 'react';
+    import Svg, { Path } from 'react-native-svg';
     import { IconProps } from '../types';
 
-    export default function ${exportName}(props: SvgProps & IconProps) {
+    export default function ${exportName}(props: IconProps) {
       const { color } = props;
 
       return ${jsx};


### PR DESCRIPTION
# Why

Currently we use props union in every generated icon component. 

Let's move this to types directly and simplify the Icon components.

# How

Move `SvgProps` to the `IconProps` declaration, update template so there is no unnecessary imports (I was not able to clean up passed imports easily, so I have decided just to define them manually, like in the main `styleguide` package).

Additionally I have added the `IconProps` export to the main package file, which address the direct `dist` imports, like in the `styleguide` package.