### PR TITLE
[styleguide] move `dark-theme` class to HTML element

### DIFF
--- a/packages/styleguide/src/components/BlockingSetInitialColorMode.tsx
+++ b/packages/styleguide/src/components/BlockingSetInitialColorMode.tsx
@@ -41,9 +41,9 @@ function setInitialColorMode() {
 
   // add HTML attribute if dark mode
   if (colorMode === 'dark') {
-    document.body.classList.add('dark-theme');
+    document.documentElement.classList.add('dark-theme');
   } else {
-    document.body.classList.remove('dark-theme');
+    document.documentElement.classList.remove('dark-theme');
   }
 }
 

--- a/packages/styleguide/src/components/ThemeProvider.tsx
+++ b/packages/styleguide/src/components/ThemeProvider.tsx
@@ -72,9 +72,9 @@ export function ThemeProvider(props: ThemeProviderProps) {
     if (disabled) return;
 
     if (themeName === Themes.DARK) {
-      document.body.classList.add('dark-theme');
+      document.documentElement.classList.add('dark-theme');
     } else {
-      document.body.classList.remove('dark-theme');
+      document.documentElement.classList.remove('dark-theme');
     }
   }
 


### PR DESCRIPTION
This small PR moves the `dark-mode` class from BODY to HTML element, which is required to fix the overscroll background color in Universe.