### PR TITLE
add `none` shadow for overwrites and for cohesion with Tailwind

### DIFF
--- a/packages/styleguide/src/styles/expo-theme.css
+++ b/packages/styleguide/src/styles/expo-theme.css
@@ -126,6 +126,7 @@
   --expo-theme-project-purple: linear-gradient(#a687e0, #8a66cc);
 
   /* Light shadows */
+  --expo-theme-shadows-none: 0 0 transparent;
   --expo-theme-shadows-xs: 0 1px 3px rgba(0, 0, 0, 0.025),
     0 1px 2px rgba(0, 0, 0, 0.05);
   --expo-theme-shadows-sm: 0 3px 6px rgba(0, 0, 0, 0.08),
@@ -248,6 +249,7 @@
   --expo-theme-project-purple: linear-gradient(#715c99, #4e3973);
 
   /* Dark shadows */
+  --expo-theme-shadows-none: 0 0 transparent;
   --expo-theme-shadows-xs: 0 1px 3px rgba(0, 0, 0, 0.3),
     0 1px 2px rgba(0, 0, 0, 0.3);
   --expo-theme-shadows-sm: 0 3px 6px rgba(0, 0, 0, 0.4),

--- a/packages/styleguide/src/styles/shadows.ts
+++ b/packages/styleguide/src/styles/shadows.ts
@@ -1,4 +1,5 @@
 export const shadows = {
+  none: 'var(--expo-theme-shadows-none)',
   xs: 'var(--expo-theme-shadows-xs)',
   sm: 'var(--expo-theme-shadows-sm)',
   md: 'var(--expo-theme-shadows-md)',


### PR DESCRIPTION
# Why

Currently we lacking an ability to overwrite the box shadow using Tailwind classes, this is also a feature reduction comparing with default Tailwind theme shadow classes:
* https://tailwindcss.com/docs/box-shadow#removing-the-shadow

# How

Add `shadows.none` theme value and required CSS variables which are set to `0 0 transparent` which is a reset value.