### PR TITLE
add subtle interaction animation, remove QoL arrow for external button links

### DIFF
--- a/packages/example-web/pages/icons.tsx
+++ b/packages/example-web/pages/icons.tsx
@@ -19,7 +19,7 @@ export default function Icons() {
             className={twMerge(
               'flex flex-col items-center justify-center py-4 px-2 gap-1 border border-transparent rounded-md transition',
               'hocus:border-secondary hocus:shadow-xs hover:cursor-pointer',
-              'active:scale-97.5'
+              'active:scale-98'
             )}
             onClick={() => copy(iconName)}
             key={iconName}>

--- a/packages/example-web/pages/ui.tsx
+++ b/packages/example-web/pages/ui.tsx
@@ -2,6 +2,7 @@ import { ButtonBase, Button, Link, LinkBase } from '@expo/styleguide';
 import type { ButtonTheme, ButtonProps } from '@expo/styleguide';
 import {
   AlignTopArrow01Icon,
+  ArrowUpRightIcon,
   BookClosedIcon,
   Diamond01Icon,
   EasMetadataIcon,
@@ -87,7 +88,7 @@ export default function UI() {
         </Button>
       </DemoTile>
       <DemoTile title="external link">
-        <Button href="https://snack.expo.dev" openInNewTab size="xs" theme="secondary">
+        <Button href="https://snack.expo.dev" openInNewTab size="xs" theme="secondary" rightSlot={<ArrowUpRightIcon />}>
           Snack
         </Button>
       </DemoTile>

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -39,7 +39,6 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@expo/styleguide-icons": "*",
     "next": ">= 13",
     "react": ">= 16"
   },

--- a/packages/styleguide/rollup.config.mjs
+++ b/packages/styleguide/rollup.config.mjs
@@ -20,8 +20,6 @@ const config = [
     ],
     external: [
       '@expo/styleguide-base',
-      '@expo/styleguide-icons',
-      'ap-style-title-case',
       'next/link',
       'react',
       'tailwind-merge'

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -1,4 +1,3 @@
-import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import React, { cloneElement } from 'react';
 import type { ReactElement } from 'react';
 import { twMerge } from 'tailwind-merge';
@@ -175,9 +174,6 @@ export const Button = (props: ButtonProps) => {
         </span>
       )}
       {isRightSlotIcon ? cloneElement(rightSlot, getIconProps(rightSlot, iconClasses)) : rightSlot}
-      {!leftSlot && !rightSlot && href && openInNewTab && (
-        <ArrowUpRightIcon className={twMerge(getIconSizeClasses(size), 'text-icon-secondary')} />
-      )}
     </Element>
   );
 };

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -45,39 +45,39 @@ function getThemeClasses(theme: ButtonTheme, disabled = false) {
     case 'primary':
       return twMerge(
         'border-button-primary bg-button-primary text-button-primary shadow-xs',
-        !disabled && 'hocus:bg-button-primary-hover',
+        !disabled && 'hocus:bg-button-primary-hover active:scale-98',
         disabled && 'bg-button-primary-disabled border-button-primary-disabled text-button-primary-disabled'
       );
     case 'primary-destructive':
       return twMerge(
         'border-button-primary-destructive bg-button-primary-destructive text-button-primary-destructive shadow-xs',
-        !disabled && 'hocus:bg-button-primary-destructive-hover',
+        !disabled && 'hocus:bg-button-primary-destructive-hover active:scale-98',
         disabled &&
           'bg-button-primary-destructive-disabled border-button-primary-destructive-disabled text-button-primary-destructive-disabled'
       );
     case 'secondary':
       return twMerge(
         'border-button-secondary bg-button-secondary text-button-secondary shadow-xs',
-        !disabled && 'hocus:bg-button-secondary-hover',
+        !disabled && 'hocus:bg-button-secondary-hover active:scale-98',
         disabled && 'bg-button-secondary-disabled border-button-secondary-disabled text-button-secondary-disabled'
       );
     case 'secondary-destructive':
       return twMerge(
         'border-button-secondary-destructive bg-button-secondary-destructive text-button-secondary-destructive shadow-xs',
-        !disabled && 'hocus:bg-button-secondary-destructive-hover',
+        !disabled && 'hocus:bg-button-secondary-destructive-hover active:scale-98',
         disabled &&
           'bg-button-secondary-destructive-disabled border-button-secondary-destructive-disabled text-button-secondary-destructive-disabled'
       );
     case 'tertiary':
       return twMerge(
         'border-button-tertiary bg-button-tertiary text-button-tertiary shadow-none',
-        !disabled && 'hocus:bg-button-tertiary-hover',
+        !disabled && 'hocus:bg-button-tertiary-hover active:scale-98',
         disabled && 'bg-button-tertiary-disabled border-button-tertiary-disabled text-button-tertiary-disabled'
       );
     case 'quaternary':
       return twMerge(
         'border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none',
-        !disabled && 'hocus:bg-button-quaternary-hover',
+        !disabled && 'hocus:bg-button-quaternary-hover active:scale-98',
         disabled && 'bg-button-quaternary-disabled border-button-quaternary-disabled text-button-quaternary-disabled'
       );
   }

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -342,7 +342,7 @@ const expoTailwindConfig = {
         inherit: 'inherit',
       },
       scale: {
-        97.5: '.975',
+        98: '.98',
       },
     },
   },

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -351,7 +351,7 @@ const expoTailwindConfig = {
   },
   plugins: [
     plugin(({ addVariant, matchUtilities, theme }) => {
-      addVariant('hocus', ['&:hover', '&:focus']);
+      addVariant('hocus', ['&:hover', '&:focus-visible']);
       matchUtilities({ heading: (value) => value }, { values: theme('heading') });
     }),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,11 +1996,6 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-ap-style-title-case@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ap-style-title-case/-/ap-style-title-case-2.0.0.tgz#c9fddb3ca94f0eb87078e3f6164efd36df2dfb82"
-  integrity sha512-8vCoCer8ZTXjvCK+JQLU0YW0EWI+70lyP9Q33mafLG0VRT7UY1BHoDq7WzaQYwzh9t+eG94tEJuVHrEDcRP1Fg==
-
 "aproba@^1.0.3 || ^2.0.0", aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"


### PR DESCRIPTION
# Why

There were some minor thing which slip through the cracks in the latest batch of PRs, let's address them.

# How

The following changes have been made:
* remove QoL "smart" arrow appended to generic external button links
* remove `styleguide` dependency on the icons package (at least for now)
* add subtle interaction animation for non-disabled buttons
* fix `hocus` variant, which used the invalid focus pseudo class, leading to visual glitches
* update lock