### PR TITLE
[styleguide] do not copy TW to `dist`, tweak Button stopwords

### DIFF
--- a/packages/styleguide/rollup.config.mjs
+++ b/packages/styleguide/rollup.config.mjs
@@ -14,7 +14,6 @@ const config = [
         targets: [
           { src: './src/styles/expo-theme.css', dest: 'dist' },
           { src: './src/styles/global.css', dest: 'dist' },
-          { src: './tailwind.js', dest: 'dist' },
         ],
       }),
     ],

--- a/packages/styleguide/src/components/Button/helpers.ts
+++ b/packages/styleguide/src/components/Button/helpers.ts
@@ -1,4 +1,4 @@
-const STOPWORDS = 'a an and at but by for in nor of on or so the to up yet'.split(' ');
+const STOPWORDS = 'a an and at but by for in nor of on or out so the to up with yet'.split(' ');
 
 type Options = {
   keepSpaces?: boolean | undefined;


### PR DESCRIPTION
# Why & how

Currently TW theme is present two times in the published bundle, on root level and in `dist`, which increases the packages size without no reason.

Additionally, during work on SSO I have found that we are missing few stop words for the Button capitalisation util, which leads to the incorrect labels.