### PR TITLE
[styleguide] add Button prop to enable skipping capitalization

### DIFF
--- a/packages/example-web/pages/ui.tsx
+++ b/packages/example-web/pages/ui.tsx
@@ -143,7 +143,8 @@ export default function UI() {
           theme="quaternary"
           className="hocus:bg-palette-yellow2 hocus:border-palette-yellow6"
           leftSlot={<span className="icon-2xs bg-palette-yellow10 rounded-md" />}
-          testID="test-button">
+          testID="test-button"
+          skipCapitalization>
           Check status
         </Button>
         <Button
@@ -151,7 +152,8 @@ export default function UI() {
           theme="quaternary"
           className="ml-4 hocus:bg-palette-yellow2 hocus:border-palette-yellow6"
           leftSlot={<span className="icon-2xs bg-palette-yellow10 rounded-md" />}
-          testID="test-link">
+          testID="test-link"
+          skipCapitalization>
           Check status
         </Button>
       </DemoTile>

--- a/packages/styleguide/README.md
+++ b/packages/styleguide/README.md
@@ -16,6 +16,7 @@ Expo's styleguide and components for use on the web.
    ```css
    @import "@expo/styleguide/dist/expo-theme.css";
    ```
+3. Add `'./node_modules/@expo/styleguide/dist/**/*.{js,ts,jsx,tsx}'` to the Tailwind `content` paths.
 
 ### Tailwind theme
 

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -21,6 +21,7 @@ export type ButtonProps = ButtonBaseProps &
     theme?: ButtonTheme;
     leftSlot?: ReactElement;
     rightSlot?: ReactElement;
+    skipCapitalization?: boolean;
   };
 
 function getSizeClasses(size: ButtonSize) {
@@ -137,6 +138,7 @@ export const Button = (props: ButtonProps) => {
     children,
     size = 'sm',
     theme = 'primary',
+    skipCapitalization = false,
     href,
     disabled,
     className,
@@ -170,7 +172,7 @@ export const Button = (props: ButtonProps) => {
       {isLeftSlotIcon ? cloneElement(leftSlot, getIconProps(leftSlot, iconClasses)) : leftSlot}
       {children && (
         <span className={mergeClasses('flex self-center text-inherit leading-none', href && 'select-none')}>
-          {typeof children === 'string' ? titleCase(children) : children}
+          {typeof children === 'string' && !skipCapitalization ? titleCase(children) : children}
         </span>
       )}
       {isRightSlotIcon ? cloneElement(rightSlot, getIconProps(rightSlot, iconClasses)) : rightSlot}


### PR DESCRIPTION
# Why

At the beginning we decide to always apply capitalization for the buttons labels, but there are some cases when it would be useful to be able to skip the formatting.

# How

This PR adds the `skipCapitalization` prop for the `Button` component which allows user to control when label formatting should apply.