### PR TITLE
[styleguide] add typography plugin, icon Button tweaks, extend demos

### DIFF
--- a/packages/example-web/components/headers.tsx
+++ b/packages/example-web/components/headers.tsx
@@ -1,16 +1,17 @@
+import { mergeClasses } from '@expo/styleguide';
 import { HTMLAttributes } from 'react';
 
-export function H1({ children, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
+export function H1({ children, className, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h1 className="heading-5xl font-black" {...rest}>
+    <h1 className={mergeClasses('heading-5xl font-black', className)} {...rest}>
       {children}
     </h1>
   );
 }
 
-export function H3({ children, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
+export function H3({ children, className, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h3 className="heading-3xl font-bold mt-10 mb-4" {...rest}>
+    <h3 className={mergeClasses('heading-3xl font-bold mt-10 mb-4', className)} {...rest}>
       {children}
     </h3>
   );

--- a/packages/example-web/pages/index.tsx
+++ b/packages/example-web/pages/index.tsx
@@ -1,11 +1,16 @@
+import { WordMarkLogo } from '@expo/styleguide';
+
 import { H1 } from '@/components/headers';
 
 export default function Home() {
   return (
     <>
-      <H1>@expo/styleguide</H1>
-      <p className="text-lg mt-4">
-        A collection of packages used to share styles and icons across Expo websites and projects.
+      <H1 className="prose-strong:text-secondary">
+        @expo<strong>/</strong>styleguide
+      </H1>
+      <p className="text-lg mt-8 prose-invert:">
+        A collection of packages used to share styles and icons across{' '}
+        <WordMarkLogo className="text-default w-auto h-6 inline relative -top-0.5 px-0.5" /> websites and projects.
       </p>
     </>
   );

--- a/packages/example-web/pages/index.tsx
+++ b/packages/example-web/pages/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <H1 className="prose-strong:text-secondary">
         @expo<strong>/</strong>styleguide
       </H1>
-      <p className="text-lg mt-8 prose-invert:">
+      <p className="text-lg mt-8">
         A collection of packages used to share styles and icons across{' '}
         <WordMarkLogo className="text-default w-auto h-6 inline relative -top-0.5 px-0.5" /> websites and projects.
       </p>

--- a/packages/example-web/pages/ui.tsx
+++ b/packages/example-web/pages/ui.tsx
@@ -5,7 +5,9 @@ import {
   ArrowUpRightIcon,
   BookClosedIcon,
   Diamond01Icon,
+  DotsHorizontalIcon,
   EasMetadataIcon,
+  EyeOffIcon,
   PaletteIcon,
   Trash01Icon,
 } from '@expo/styleguide-icons';
@@ -111,6 +113,19 @@ export default function UI() {
           Delete
         </Button>
       </DemoTile>
+      <H3>Icon Buttons</H3>
+      <DemoTile title="default size">
+        <Button href="#" theme="secondary" leftSlot={<AlignTopArrow01Icon />} />
+      </DemoTile>
+      <DemoTile title="medium">
+        <Button theme="primary-destructive" size="md" leftSlot={<Trash01Icon />} />
+      </DemoTile>
+      <DemoTile title="xs">
+        <Button theme="secondary-destructive" size="xs" leftSlot={<EyeOffIcon />} />
+      </DemoTile>
+      <DemoTile title="2xl">
+        <Button theme="quaternary" size="2xl" leftSlot={<DotsHorizontalIcon />} />
+      </DemoTile>
       <H3>Customized Buttons</H3>
       <DemoTile title="icon with custom color">
         <Button theme="secondary" size="lg" leftSlot={<Diamond01Icon className="text-palette-pink10" />}>
@@ -156,6 +171,16 @@ export default function UI() {
           skipCapitalization>
           Check status
         </Button>
+      </DemoTile>
+      <DemoTile title="forced dark theme">
+        <span className="dark-theme flex bg-screen p-4 rounded-lg gap-4">
+          <Button theme="secondary" className="dark-theme">
+            Dark button
+          </Button>
+          <Button href="#" theme="secondary-destructive" className="dark-theme">
+            Dark button #2
+          </Button>
+        </span>
       </DemoTile>
     </>
   );

--- a/packages/styleguide/README.md
+++ b/packages/styleguide/README.md
@@ -24,7 +24,9 @@ For the Styleguide we use our custom Tailwind theme, which is based on the defau
 * only valid media screen scopes are: `xs:`, `sm:`, `md:`, `lg:` and `xl:`
 * there is a custom `hocus:` scope which is a shorthand for hover and focus states
 * typography elements are predefined as a `heading-[size]` styles sets
-* `icon-[size]` are custom component classes defined for icons sizing 
+* `icon-[size]` are custom component classes defined for icons sizing
+
+The theme can be extended, if needed, and includes `@tailwindcss/typography` plugin by default, with a stripped down version of default config.
 
 ## Development
 

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.0.0",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/react": "^18.0.28",
     "npm-run-all": "^4.1.5",
     "rimraf": "^4.1.2",

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -118,6 +118,23 @@ function getThemedIconClasses(theme: ButtonTheme) {
   }
 }
 
+function getButtonIconClasses(size: ButtonSize) {
+  switch (size) {
+    case 'xs':
+      return 'px-0 w-8 justify-center items-center';
+    case 'sm':
+      return 'px-0 w-9 justify-center items-center';
+    case 'md':
+      return 'px-0 w-10 justify-center items-center';
+    case 'lg':
+      return 'px-0 w-11 justify-center items-center';
+    case 'xl':
+      return 'px-0 w-12 justify-center items-center';
+    case '2xl':
+      return 'px-0 w-15 justify-center items-center';
+  }
+}
+
 function isIconElement(element: ReactElement) {
   if (React.isValidElement(element)) {
     // @ts-ignore React Portal did not have `displayName` prop, but it is a valid element
@@ -157,6 +174,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLLinkElement, ButtonProp
     const iconClasses =
       (isLeftSlotIcon || isRightSlotIcon) &&
       mergeClasses(`${getIconSizeClasses(size)}`, getThemedIconClasses(theme), disabled && 'opacity-60');
+    const isSingleIconButton = (leftSlot || rightSlot) && !children;
 
     return (
       <Element
@@ -165,6 +183,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLLinkElement, ButtonProp
           `inline-flex border border-solid rounded-md font-medium gap-2 items-center whitespace-nowrap transition`,
           getSizeClasses(size),
           getThemeClasses(theme, disabled),
+          isSingleIconButton && getButtonIconClasses(size),
           disabled && 'cursor-default opacity-80 pointer-event-none',
           className
         )}

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -344,6 +344,9 @@ const expoTailwindConfig = {
       height: {
         15: '3.75rem',
       },
+      width: {
+        15: '3.75rem',
+      },
       opacity: {
         inherit: 'inherit',
       },
@@ -363,6 +366,18 @@ const expoTailwindConfig = {
       transitionDuration: {
         default: '150ms',
       },
+      typography: () => ({
+        DEFAULT: {
+          css: {
+            sm: null,
+            base: null,
+            lg: null,
+            xl: null,
+            '2xl': null,
+            invert: null,
+          },
+        },
+      }),
     },
   },
   corePlugins: {
@@ -404,6 +419,7 @@ const expoTailwindConfig = {
         },
       });
     }),
+    require('@tailwindcss/typography'),
   ],
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,6 +1592,16 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/typography@^0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.9.tgz#027e4b0674929daaf7c921c900beee80dbad93e8"
+  integrity sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -4818,10 +4828,20 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -5879,6 +5899,14 @@ postcss-nested@6.0.0:
   integrity sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==
   dependencies:
     postcss-selector-parser "^6.0.10"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11:
   version "6.0.11"


### PR DESCRIPTION
# Why & How

This PR performs the following chnages:
* [styleguide] add `@tailwind/typography` plugin with a stripped down default config to the theme
* [styleguide] improvements for the icon only Button
* [example-web] add `prose` usage example
* [example-web] add forced dark mode usage examples