### PR TITLE
Adds duotone icons

### DIFF
--- a/packages/example-web/pages/icons.tsx
+++ b/packages/example-web/pages/icons.tsx
@@ -19,7 +19,7 @@ export default function Icons() {
   return (
     <>
       <H1>Icons</H1>
-      <H3>Logs</H3>
+      <H3>Logos</H3>
       <div className="mt-8 grid grid-cols-1 gap-2 xl:grid-cols-6 lg:grid-cols-4 md:grid-cols-3 ">
         {[
           { name: 'WordMarkLogo', element: WordMarkLogo },

--- a/packages/styleguide-icons/figma.config.js
+++ b/packages/styleguide-icons/figma.config.js
@@ -104,6 +104,32 @@ const outlineSVGOConfig = [
   },
 ];
 
+/** @type {import('svgo').PluginConfig[]} */
+const duotoneSVGOConfig = [
+  {
+    name: 'removeDimensions',
+    active: true,
+  },
+  {
+    name: 'sortAttrs',
+    active: true,
+  },
+  {
+    name: 'removeAttrs',
+    params: {
+      attrs: 'stroke',
+    },
+  },
+  {
+    name: 'addAttributesToSVGElement',
+    params: {
+      attribute: {
+        stroke: 'currentColor',
+      },
+    },
+  },
+];
+
 /** @type {import('@figma-export/types').FigmaExportRC} */
 module.exports = {
   commands: [
@@ -113,6 +139,15 @@ module.exports = {
         fileId,
         onlyFromPages: ['outline'],
         transformers: [svgo({ multipass: true, plugins: outlineSVGOConfig })],
+        outputters,
+      },
+    ],
+    [
+      'components',
+      {
+        fileId,
+        onlyFromPages: ['duotone'],
+        transformers: [svgo({ multipass: true, plugins: duotoneSVGOConfig })],
         outputters,
       },
     ],

--- a/packages/styleguide-icons/index.ts
+++ b/packages/styleguide-icons/index.ts
@@ -1,3 +1,4 @@
 export * from './tmp/solid';
 export * from './tmp/outline';
+export * from './tmp/duotone';
 export * from './tmp/custom';


### PR DESCRIPTION
# Why

We'd like to use the duotone icons from Figma in our website as we have them in our designs.

I also noticed that the `<PlanOnDemandIcon>` was not exported correctly and was missing the inner triangle in the icon, since there was a mask on the icon. I updated that icon and fixed it such that we don't need a mask.

# Screenshots

<img width="420" alt="Screenshot 2023-05-22 at 5 04 23 PM" src="https://github.com/expo/styleguide/assets/6455018/527fc578-4269-411c-9402-59ff589309c4">
<img width="189" alt="Screenshot 2023-05-22 at 5 15 39 PM" src="https://github.com/expo/styleguide/assets/6455018/deda7901-e28a-4f3a-87df-30c3a377df3e">
<img width="195" alt="Screenshot 2023-05-22 at 5 15 48 PM" src="https://github.com/expo/styleguide/assets/6455018/32ee8e32-a532-4a37-9380-8749beb4d559">


# Test plan

1. In styleguide-icons, run `yarn build-icons`
2. In the parent directory of styleguide, run `yarn dev`
3. Then, open localhost:3000/icons

You should see duotone icons. Also, you should see the `<StoplightIcon>`. 