### PR TITLE
[example-web] add search and filters for icon list

### DIFF
--- a/packages/example-web/pages/_app.tsx
+++ b/packages/example-web/pages/_app.tsx
@@ -43,7 +43,7 @@ export default function App({ Component, pageProps }: AppProps) {
       </Head>
       <main className="flex p-8 gap-8">
         <Sidebar />
-        <div className="pl-[240px] max-w-full">
+        <div className="pl-[240px] max-w-full w-full">
           <Component {...pageProps} />
         </div>
       </main>

--- a/packages/example-web/pages/icons.tsx
+++ b/packages/example-web/pages/icons.tsx
@@ -1,6 +1,16 @@
-import { Logo, DocsLogo, ExpoGoLogo, SnackLogo, WordMarkLogo, RouterLogo, mergeClasses } from '@expo/styleguide';
+import {
+  Logo,
+  DocsLogo,
+  ExpoGoLogo,
+  SnackLogo,
+  WordMarkLogo,
+  RouterLogo,
+  mergeClasses,
+  Button,
+} from '@expo/styleguide';
 import * as StyleguideIcons from '@expo/styleguide-icons';
-import { createElement } from 'react';
+import { CheckCircleIcon, PlaceholderIcon, SearchMdIcon } from '@expo/styleguide-icons';
+import { createElement, useState } from 'react';
 
 import { H1, H3 } from '@/components/headers';
 import useCopy from '@/hooks/useCopy';
@@ -15,9 +25,22 @@ const iconClasses = mergeClasses(
 
 export default function Icons() {
   const [, copy] = useCopy();
-  const iconNames = Object.keys(StyleguideIcons).filter((key) => key.endsWith('Icon')) as IconNames[];
+  const [filters, setFilters] = useState({ outline: true, solid: false, duotone: false });
+  const [search, setSearch] = useState('');
+
+  const iconNames = Object.keys(StyleguideIcons)
+    .filter((key) => {
+      let skip = false;
+      if (!filters.solid) skip = skip || key.endsWith('SolidIcon');
+      if (!filters.duotone) skip = skip || key.endsWith('DuotoneIcon');
+      if (!filters.outline) skip = skip || (!key.endsWith('SolidIcon') && !key.endsWith('DuotoneIcon'));
+      return !skip;
+    })
+    .filter((key) => (search ? key.toLowerCase().includes(search) : true))
+    .filter((key) => key.endsWith('Icon')) as IconNames[];
+
   return (
-    <>
+    <div>
       <H1>Icons</H1>
       <H3>Logs</H3>
       <div className="mt-8 grid grid-cols-1 gap-2 xl:grid-cols-6 lg:grid-cols-4 md:grid-cols-3 ">
@@ -36,6 +59,39 @@ export default function Icons() {
         ))}
       </div>
       <H3>Icon set</H3>
+      <div className="flex items-center gap-4">
+        <div className="relative">
+          <SearchMdIcon className="icon-sm absolute top-[9px] left-2.5" />
+          <input
+            className="border border-default rounded-md bg-default shadow-none py-1 px-3 pl-8 box-border outline-palette-blue8"
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div>
+          <Button
+            theme={filters.outline ? 'tertiary' : 'quaternary'}
+            leftSlot={
+              filters.outline ? <CheckCircleIcon className="icon-sm" /> : <PlaceholderIcon className="icon-sm" />
+            }
+            onClick={() => setFilters((prevState) => ({ ...prevState, outline: !prevState.outline }))}>
+            Outline
+          </Button>
+          <Button
+            theme={filters.solid ? 'tertiary' : 'quaternary'}
+            leftSlot={filters.solid ? <CheckCircleIcon className="icon-sm" /> : <PlaceholderIcon className="icon-sm" />}
+            onClick={() => setFilters((prevState) => ({ ...prevState, solid: !prevState.solid }))}>
+            Solid
+          </Button>
+          <Button
+            theme={filters.duotone ? 'tertiary' : 'quaternary'}
+            leftSlot={
+              filters.duotone ? <CheckCircleIcon className="icon-sm" /> : <PlaceholderIcon className="icon-sm" />
+            }
+            onClick={() => setFilters((prevState) => ({ ...prevState, duotone: !prevState.duotone }))}>
+            Duotone
+          </Button>
+        </div>
+      </div>
       <div className="mt-8 grid grid-cols-1 gap-2 xl:grid-cols-6 lg:grid-cols-4 md:grid-cols-3 ">
         {iconNames.map((iconName) => (
           <div className={iconClasses} onClick={() => copy(iconName)} key={iconName}>
@@ -44,6 +100,6 @@ export default function Icons() {
           </div>
         ))}
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
# Why

While testing out the new Duotone icons variant addition, I have spotted that icons page in test app started to lag a bit.

This happens due to shear amount of DOM we output in there (3500+ SVG icons), so I decided to implement basic filters and search functionality.

# How

Display only outline icons by default to aid page performance, add filters for icon variants, add very basic search implementation.

# Preview

https://github.com/expo/styleguide/assets/719641/903542b2-5835-42ec-9579-d9cabe4ba457
