### PR TITLE
[styleguide] allow using semantic background colors for `stroke`

### DIFF
--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -332,6 +332,19 @@ const expoTailwindConfig = {
       'xl-gutters': '1248px',
     },
     extend: {
+      stroke: {
+        'bg-default': 'var(--expo-theme-background-default)',
+        'bg-screen': 'var(--expo-theme-background-screen)',
+        'bg-subtle': 'var(--expo-theme-background-subtle)',
+        'bg-element': 'var(--expo-theme-background-element)',
+        'bg-hover': 'var(--expo-theme-background-hover)',
+        'bg-selected': 'var(--expo-theme-background-selected)',
+        'bg-overlay': 'var(--expo-theme-background-overlay)',
+        'bg-success': 'var(--expo-theme-background-success)',
+        'bg-warning': 'var(--expo-theme-background-warning)',
+        'bg-danger': 'var(--expo-theme-background-danger)',
+        'bg-info': 'var(--expo-theme-background-info)',
+      },
       height: {
         15: '3.75rem',
       },


### PR DESCRIPTION
# Why

Why working on new Styleguide conversion in Expo dashboard and new Home page I have found that there are cases, where we were using background semantic colors for `stroke` SVG attribute.

It is possible to use the raw palette colors in there, but from time to time dark theme scope alterations are required.

# How

This PR adds the semantic background colors to our TW theme `stroke` classes. I have to use `bg-` prefix, since semantic text colors are propagated by default to strokes.

# Test steps

After making changes to the theme I have build the package and tested the new classes using example-web (but I did not add any permanent test cases for that).