### PR TITLE
[styleguide] move in more general website config changes, bump merge helper

### DIFF
--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -16,7 +16,7 @@
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwind-merge": "^1.12.0",
+    "tailwind-merge": "^1.13.2",
     "typescript": "4.9.5"
   },
   "devDependencies": {

--- a/packages/example-web/pages/colors.tsx
+++ b/packages/example-web/pages/colors.tsx
@@ -158,6 +158,35 @@ export default function Colors() {
           </div>
         ))}
       </div>
+      <H3>Project background colors</H3>
+      <div className="flex flex-wrap mb-2">
+        {[
+          'bg-app-cyan',
+          'bg-app-light-blue',
+          'bg-app-dark-blue',
+          'bg-app-indigo',
+          'bg-app-purple',
+          'bg-app-pink',
+          'bg-app-orange',
+          'bg-app-gold',
+          'bg-app-yellow',
+          'bg-app-lime',
+          'bg-app-light-green',
+          'bg-app-dark-green',
+        ].map((className, index) => (
+          <div key={index}>
+            <div
+              className={mergeClasses(
+                'w-16 h-16 mb-1 transition',
+                'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                className
+              )}
+              onClick={() => copy(className)}
+            />
+            <p className="text-3xs text-secondary text-center">{className.replace('bg-app-', '')}</p>
+          </div>
+        ))}
+      </div>
     </>
   );
 }

--- a/packages/styleguide-icons/package.json
+++ b/packages/styleguide-icons/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/expo/styleguide/issues"
   },
   "dependencies": {
-    "tailwind-merge": "^1.12.0"
+    "tailwind-merge": "^1.13.2"
   },
   "devDependencies": {
     "@figma-export/cli": "^4.5.0",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@expo/styleguide-base": "^1.0.0",
-    "tailwind-merge": "^1.12.0"
+    "tailwind-merge": "^1.13.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -102,6 +102,8 @@ const palette = {
 };
 
 const expoTailwindConfig = {
+  safelist: ['icon-md', 'text-icon-default'],
+  darkMode: ['class', '[class="dark-theme"]'],
   theme: {
     borderRadius: {
       none: 0,
@@ -345,6 +347,21 @@ const expoTailwindConfig = {
         'bg-danger': 'var(--expo-theme-background-danger)',
         'bg-info': 'var(--expo-theme-background-info)',
       },
+      backgroundColor: {
+        'app-cyan': '#07c0cb',
+        'app-light-blue': '#1e92c4',
+        'app-dark-blue': '#0b67af',
+        'app-indigo': '#4b50b2',
+        'app-purple': '#8945a3',
+        'app-pink': '#c04891',
+        'app-orange': '#e96d3c',
+        'app-gold': '#f38f2f',
+        'app-yellow': '#eebc01',
+        'app-lime': '#aabd04',
+        'app-light-green': '#6aa72a',
+        'app-dark-green': '#3a8e39',
+        transparent: 'transparent',
+      },
       height: {
         15: '3.75rem',
       },
@@ -356,6 +373,9 @@ const expoTailwindConfig = {
       },
       scale: {
         98: '.98',
+        1025: '1.025',
+        175: '1.75',
+        200: '2.0',
       },
       gridTemplateColumns: {
         'auto-min-1': 'auto',
@@ -420,6 +440,12 @@ const expoTailwindConfig = {
         '.icon-2xl': {
           height: theme('height.10'),
           width: theme('width.10'),
+        },
+        '.break-words': { 'word-break': 'break-word' },
+        '.pause-animation': { 'animation-play-state': 'paused' },
+        '.transform-box': { 'transform-box': 'fill-box' },
+        '.backface-hidden': {
+          'backface-visibility': 'hidden',
         },
       });
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6863,10 +6863,10 @@ synckit@^0.8.4:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
-tailwind-merge@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.12.0.tgz#747d09d64a25a4864150e8930f8e436866066cc8"
-  integrity sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==
+tailwind-merge@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.13.2.tgz#1d06c9e95ffda2320efc50ed33c65be0cda23091"
+  integrity sha512-R2/nULkdg1VR/EL4RXg4dEohdoxNUJGLMnWIQnPKL+O9Twu7Cn3Rxi4dlXkDzZrEGtR+G+psSXFouWlpTyLhCQ==
 
 tailwindcss@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
# Why

During the latest development towards TW adoption on the website we have introduced few more changes to our TW config. However, part of those can be moved in into our generic config, so other sites/products can also benefit from those additions, and this PR does exactly that.

# How

Move in into base TW config the project icon background colors, icon classes safelist, theme settings, additional scale options and few other utility classes.

I have also added the project colors previe win the example app and bumped the `tailwind-merge` across the workspace.

# Preview

<img width="893" alt="Screenshot 2023-06-29 at 11 04 20" src="https://github.com/expo/styleguide/assets/719641/31e54db9-dc64-4f52-98ec-acee5b52397f">
