### PR TITLE
fix initial theme apply by preventing color mode functions removal

### DIFF
--- a/packages/styleguide/rollup.config.mjs
+++ b/packages/styleguide/rollup.config.mjs
@@ -11,7 +11,9 @@ const config = [
     },
     plugins: [
       typescript(),
-      terser(),
+      terser({
+        keep_fnames: /.+ColorMode/
+      }),
       copy({
         targets: [
           { src: './src/styles/expo-theme.css', dest: 'dist' },


### PR DESCRIPTION
# Why

Superseds #67

# How

Fixes the incorrect initial theme setting when dark mode was set as default by preventing Terser from removing `*ColorMode` function during output `dist` optimization and compression.

# Test plan

The changes have been tested with included in repo `example-app`.