### PR TITLE
[search-ui] tweaks for styling issues when used in docs

### DIFF
--- a/packages/search-ui/src/Items/ExpoDocsItem.tsx
+++ b/packages/search-ui/src/Items/ExpoDocsItem.tsx
@@ -82,7 +82,7 @@ export const ExpoDocsItem = ({ item, onSelect, isNested, transformUrl = (url: st
 
   return (
     <CommandItemBase
-      className={mergeClasses(isNested && 'ml-8 mt-0.5 min-h-[32px]')}
+      className={mergeClasses(isNested && 'ml-8 !min-h-[32px]')}
       value={`expodocs-${item.objectID}`}
       onSelect={onSelect}
       url={transformUrl(item.url)}

--- a/packages/search-ui/src/components/CommandMenuTrigger.tsx
+++ b/packages/search-ui/src/components/CommandMenuTrigger.tsx
@@ -44,7 +44,7 @@ export const CommandMenuTrigger = ({ setOpen, className }: Props) => {
       }
       className={mergeClasses('bg-default pl-2.5 pr-3 border border-default shadow-xs min-h-[40px]', className)}
       onClick={() => setOpen(true)}>
-      <p className="text-secondary text-xs">Search</p>
+      <p className="text-secondary font-normal leading-normal text-xs">Search</p>
     </Button>
   );
 };

--- a/packages/search-ui/src/styles/expo-search-ui.css
+++ b/packages/search-ui/src/styles/expo-search-ui.css
@@ -129,10 +129,6 @@
   margin-top: 4px;
 }
 
-[cmdk-item][data-nested] + [cmdk-item] {
-  margin-top: 8px;
-}
-
 [cmdk-item] mark {
   color: var(--blue12);
   background: var(--blue4);


### PR DESCRIPTION
# Why & how

There were small styling issues when testing integration in our docs, which are caused by loading order of styles.

This PR alters code a bit, so the problematic overwrites should not happen.