### PR TITLE
[search-ui] allow multiple triggers, style tweaks

### DIFF
--- a/packages/example-web/pages/ui.tsx
+++ b/packages/example-web/pages/ui.tsx
@@ -67,21 +67,24 @@ export default function UI() {
     <>
       <H1>UI</H1>
       <H3>Search</H3>
+      <CommandMenu
+        config={{ docsVersion: 'latest' }}
+        open={open}
+        setOpen={setOpen}
+        customSections={[
+          {
+            heading: 'Expo Dashboard',
+            items: expoItems,
+            getItemsAsync: getExpoItems,
+            sectionIndex: 1,
+          },
+        ]}
+      />
       <DemoTile title="@expo/search-ui">
-        <CommandMenu
-          config={{ docsVersion: 'latest', disableDashboardSection: true }}
-          open={open}
-          setOpen={setOpen}
-          customSections={[
-            {
-              heading: 'Expo Dashboard',
-              items: expoItems,
-              getItemsAsync: getExpoItems,
-              sectionIndex: 1,
-            },
-          ]}
-        />
-        <CommandMenuTrigger setOpen={setOpen} className="min-w-[180px]" />
+        <CommandMenuTrigger setOpen={setOpen} />
+      </DemoTile>
+      <DemoTile title="@expo/search-ui custom trigger">
+        <CommandMenuTrigger setOpen={setOpen} className="min-w-[220px] border-info bg-info hocus:bg-palette-blue4" />
       </DemoTile>
       <H3>Link Base</H3>
       <DemoTile title="local anchor">

--- a/packages/search-ui/src/components/CommandMenu.tsx
+++ b/packages/search-ui/src/components/CommandMenu.tsx
@@ -7,7 +7,7 @@ import { BarLoader } from './BarLoader';
 import { CommandFooter } from './CommandFooter';
 import { RNDirectoryItem, RNDocsItem, ExpoDocsItem } from '../Items';
 import type { RNDirectoryItemType, AlgoliaItemType, CommandMenuConfig, CommandMenuSection } from '../types';
-import { getExpoDocsResults, getRNDocsResults, getDirectoryResults, getItemsAsync } from '../utils';
+import { getExpoDocsResults, getRNDocsResults, getDirectoryResults, getItemsAsync, isAppleDevice } from '../utils';
 
 type Props = {
   open: boolean;
@@ -25,6 +25,7 @@ export const CommandMenu = ({
   const [initialized, setInitialized] = useState(false);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState('');
+  const [isMac, setIsMac] = useState<boolean | null>(null);
 
   const [expoDocsItems, setExpoDocsItems] = useState<AlgoliaItemType[]>([]);
   const [rnDocsItems, setRnDocsItems] = useState<AlgoliaItemType[]>([]);
@@ -61,6 +62,23 @@ export const CommandMenu = ({
       });
     }
   };
+
+  useEffect(() => {
+    setIsMac(typeof navigator !== 'undefined' && isAppleDevice());
+  }, []);
+
+  useEffect(() => {
+    if (isMac !== null) {
+      const keyDownListener = (e: KeyboardEvent) => {
+        if (e.key === 'k' && (isMac ? e.metaKey : e.ctrlKey)) {
+          e.preventDefault();
+          setOpen((open) => !open);
+        }
+      };
+      document.addEventListener('keydown', keyDownListener, false);
+      return () => document.removeEventListener('keydown', keyDownListener);
+    }
+  }, [isMac]);
 
   useEffect(onMenuOpen, [open]);
   useEffect(onQueryChange, [query]);

--- a/packages/search-ui/src/components/CommandMenuTrigger.tsx
+++ b/packages/search-ui/src/components/CommandMenuTrigger.tsx
@@ -16,22 +16,8 @@ export const CommandMenuTrigger = ({ setOpen, className }: Props) => {
     setIsMac(typeof navigator !== 'undefined' && isAppleDevice());
   }, []);
 
-  useEffect(() => {
-    if (isMac !== null) {
-      const keyDownListener = (e: KeyboardEvent) => {
-        if (e.key === 'k' && (isMac ? e.metaKey : e.ctrlKey)) {
-          e.preventDefault();
-          setOpen((open) => !open);
-        }
-      };
-      document.addEventListener('keydown', keyDownListener, false);
-      return () => document.removeEventListener('keydown', keyDownListener);
-    }
-  }, [isMac]);
-
   return (
     <Button
-      id="cmdk-trigger"
       theme="secondary"
       leftSlot={<SearchSmIcon className="icon-md text-icon-secondary" />}
       rightSlot={
@@ -42,7 +28,7 @@ export const CommandMenuTrigger = ({ setOpen, className }: Props) => {
           </div>
         ) : undefined
       }
-      className={mergeClasses('bg-default pl-2.5 pr-3 border border-default shadow-xs min-h-[40px]', className)}
+      className={mergeClasses('cmdk-trigger bg-default pl-2.5 pr-3 border border-default shadow-xs min-h-[40px]', className)}
       onClick={() => setOpen(true)}>
       <p className="text-secondary font-normal leading-normal text-xs">Search</p>
     </Button>

--- a/packages/search-ui/src/components/CommandMenuTrigger.tsx
+++ b/packages/search-ui/src/components/CommandMenuTrigger.tsx
@@ -22,7 +22,7 @@ export const CommandMenuTrigger = ({ setOpen, className }: Props) => {
       leftSlot={<SearchSmIcon className="icon-md text-icon-secondary" />}
       rightSlot={
         isMac !== null ? (
-          <div className="ml-auto max-lg-gutters:hidden">
+          <div className="ml-auto max-md-gutters:hidden">
             <kbd className="!h-5 !leading-[19px]">{isMac ? '⌘' : 'Ctrl'}</kbd>{' '}
             <kbd className="!h-5 !leading-[19px]">K</kbd>
           </div>

--- a/packages/search-ui/src/styles/expo-search-ui.css
+++ b/packages/search-ui/src/styles/expo-search-ui.css
@@ -23,13 +23,7 @@
   position: fixed;
   top: 0;
   width: 100vw;
-  z-index: 200;
-}
-
-@media screen and (max-width: 788px) {
-  [cmdk-overlay] {
-    display: none;
-  }
+  z-index: 1000;
 }
 
 [cmdk-root] {
@@ -58,7 +52,7 @@
   }
 }
 
-[cmdk-root] kbd, #cmdk-trigger kbd {
+[cmdk-root] kbd, .cmdk-trigger kbd {
   font-size: 0.8125rem;
   line-height: 19px;
   letter-spacing: -0.003rem;
@@ -85,7 +79,8 @@
   font: inherit;
   height: 100%;
   outline: none;
-  padding: 12px 44px;
+  padding: 0 44px;
+  min-height: 46px;
   margin: 16px 16px 0;
   border: 1px solid var(--expo-theme-border-default);
   border-radius: 6px;


### PR DESCRIPTION
# Why & How

To do not overcomplicate layouts logic we need to make sure using multiple triggers and sharing dialog state via context is possible.

The example app has been updated to include multiple triggers to test the change.

# Preview

<img width="713" alt="Screenshot 2023-11-10 at 19 05 57" src="https://github.com/expo/styleguide/assets/719641/e41e0519-3a73-4da6-a5e2-d1dc3d350012">
