### PR TITLE
[search-ui] re-export CMDK `Item` component

### DIFF
--- a/packages/example-web/components/search/QuickActionItem.tsx
+++ b/packages/example-web/components/search/QuickActionItem.tsx
@@ -1,7 +1,6 @@
 import { Themes, useTheme } from '@expo/styleguide';
 import { BuildIcon } from '@expo/styleguide-icons';
-import { addHighlight } from '@expo/styleguide-search-ui';
-import { Command } from 'cmdk';
+import { addHighlight, CommandItemBase } from '@expo/styleguide-search-ui';
 import { type ComponentType, HTMLAttributes } from 'react';
 
 type Props = {
@@ -28,11 +27,11 @@ export const QuickActionToggleThemeItem = ({ item, query }: Props) => {
   }
 
   return (
-    <Command.Item value={`quick-action-${item.label}`} onSelect={toggleTheme}>
+    <CommandItemBase value={`quick-action-${item.label}`} onSelect={toggleTheme}>
       <div className="inline-flex gap-3 items-center">
         <Icon className="text-icon-secondary" />
         <p className="text-xs font-medium" dangerouslySetInnerHTML={{ __html: addHighlight(item.label, query) }} />
       </div>
-    </Command.Item>
+    </CommandItemBase>
   );
 };

--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -9,6 +9,9 @@
     "clean": "rimraf .next"
   },
   "dependencies": {
+    "@expo/styleguide": "latest",
+    "@expo/styleguide-icons": "latest",
+    "@expo/styleguide-search-ui": "latest",
     "@types/node": "^18.18.9",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/packages/search-ui/index.ts
+++ b/packages/search-ui/index.ts
@@ -1,6 +1,10 @@
+import { Command } from 'cmdk';
+
 export { CommandMenu } from './src/components/CommandMenu';
 export { CommandMenuTrigger } from './src/components/CommandMenuTrigger';
-export { CommandItemBase } from './src/components/CommandItemBase';
+export { CommandItemBaseWithCopy } from './src/components/CommandItemBaseWithCopy';
 
 export { addHighlight } from './src/utils';
 export * from './src/types';
+
+export const CommandItemBase = Command.Item;

--- a/packages/search-ui/src/Items/ExpoDocsItem.tsx
+++ b/packages/search-ui/src/Items/ExpoDocsItem.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 import { FootnoteSection } from './FootnoteSection';
 import { FootnoteArrowIcon } from './icons';
-import { CommandItemBase } from '../components/CommandItemBase';
+import { CommandItemBaseWithCopy } from '../components/CommandItemBaseWithCopy';
 import type { AlgoliaItemType } from '../types';
 import {
   getContentHighlightHTML,
@@ -81,7 +81,7 @@ export const ExpoDocsItem = ({ item, onSelect, isNested, transformUrl = (url: st
   const hierarchyClasses = mergeClasses('text-3xs text-quaternary', isNested && 'hidden');
 
   return (
-    <CommandItemBase
+    <CommandItemBaseWithCopy
       className={mergeClasses(isNested && 'ml-8 !min-h-[32px]')}
       value={`expodocs-${item.objectID}`}
       onSelect={onSelect}
@@ -154,6 +154,6 @@ export const ExpoDocsItem = ({ item, onSelect, isNested, transformUrl = (url: st
           )}
         </div>
       </div>
-    </CommandItemBase>
+    </CommandItemBaseWithCopy>
   );
 };

--- a/packages/search-ui/src/Items/RNDirectoryItem.tsx
+++ b/packages/search-ui/src/Items/RNDirectoryItem.tsx
@@ -2,7 +2,7 @@ import { GithubIcon } from '@expo/styleguide-icons';
 import React from 'react';
 
 import { ExternalLinkIcon } from './icons';
-import { CommandItemBase } from '../components/CommandItemBase';
+import { CommandItemBaseWithCopy } from '../components/CommandItemBaseWithCopy';
 import type { RNDirectoryItemType } from '../types';
 import { addHighlight } from '../utils';
 
@@ -16,7 +16,7 @@ const numberFormat = new Intl.NumberFormat();
 
 export const RNDirectoryItem = ({ item, onSelect, query }: Props) => {
   return (
-    <CommandItemBase value={`rnd-${item.npmPkg}`} url={item.githubUrl} isExternalLink onSelect={onSelect}>
+    <CommandItemBaseWithCopy value={`rnd-${item.npmPkg}`} url={item.githubUrl} isExternalLink onSelect={onSelect}>
       <div className="inline-flex gap-3 items-center">
         <GithubIcon className="text-icon-secondary" />
         <div>
@@ -27,6 +27,6 @@ export const RNDirectoryItem = ({ item, onSelect, query }: Props) => {
         </div>
         <ExternalLinkIcon />
       </div>
-    </CommandItemBase>
+    </CommandItemBaseWithCopy>
   );
 };

--- a/packages/search-ui/src/Items/RNDocsItem.tsx
+++ b/packages/search-ui/src/Items/RNDocsItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { FootnoteSection } from './FootnoteSection';
 import { ExternalLinkIcon, ReactIcon } from './icons';
-import { CommandItemBase } from '../components/CommandItemBase';
+import { CommandItemBaseWithCopy } from '../components/CommandItemBaseWithCopy';
 import type { AlgoliaItemType } from '../types';
 import { getContentHighlightHTML, getHighlightHTML } from '../utils';
 
@@ -14,7 +14,7 @@ type Props = {
 export const RNDocsItem = ({ item, onSelect }: Props) => {
   const { lvl0, lvl1, lvl2, lvl3, lvl4 } = item.hierarchy;
   return (
-    <CommandItemBase value={`rn-${item.objectID}`} url={item.url} isExternalLink onSelect={onSelect}>
+    <CommandItemBaseWithCopy value={`rn-${item.objectID}`} url={item.url} isExternalLink onSelect={onSelect}>
       <div className="inline-flex gap-3 items-center">
         <ReactIcon className="shrink-0" />
         <div>
@@ -59,6 +59,6 @@ export const RNDocsItem = ({ item, onSelect }: Props) => {
         </div>
         <ExternalLinkIcon />
       </div>
-    </CommandItemBase>
+    </CommandItemBaseWithCopy>
   );
 };

--- a/packages/search-ui/src/components/CommandItemBaseWithCopy.tsx
+++ b/packages/search-ui/src/components/CommandItemBaseWithCopy.tsx
@@ -13,10 +13,15 @@ type Props = PropsWithChildren<{
   value?: string;
 }>;
 
-/**
- * Wrapper for Command.Item that adds copy link on right/middle click + visual copy indicator.
- */
-export const CommandItemBase = ({ children, url, isExternalLink, isNested, onSelect, className, value }: Props) => {
+export const CommandItemBaseWithCopy = ({
+  children,
+  url,
+  isExternalLink,
+  isNested,
+  onSelect,
+  className,
+  value,
+}: Props) => {
   const [copyDone, setCopyDone] = useState(false);
 
   const copyUrl = () => {


### PR DESCRIPTION
# Why & How

Re-export `Command.Item` from the `search-ui` package to prevent using `cmdk` exports directly for custom components.

Add `@expo/styleguide` packages entries to the example app dependencies to fix CI build errors.