### PR TITLE
[styleguide] fix Tailwind config dark mode matcher

### DIFF
--- a/packages/example-web/pages/_document.tsx
+++ b/packages/example-web/pages/_document.tsx
@@ -3,7 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html>
+    <Html className="a-test-class">
       <Head />
       <body className="bg-screen text-default min-h-[100dvh]">
         <BlockingSetInitialColorMode />

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -103,7 +103,7 @@ const palette = {
 
 const expoTailwindConfig = {
   safelist: ['icon-md', 'text-icon-default'],
-  darkMode: ['class', '[class="dark-theme"]'],
+  darkMode: ['class', '[class*="dark-theme"]'],
   theme: {
     borderRadius: {
       none: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,19 +247,19 @@
     tailwind-merge "^1.13.2"
 
 "@expo/styleguide-search-ui@latest":
-  version "1.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-search-ui/-/styleguide-search-ui-1.0.0-alpha.5.tgz#f67595fbd0a24068e97f60da2239cd91db696bfc"
-  integrity sha512-EkSt4Mx3V0oZU7Gn5MNW8fsvz16KsrmcjmzyMowKMQXx82STsTDgio+KemX74wXxu8D0gkyByZYpqJWmOC7hCw==
+  version "1.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-search-ui/-/styleguide-search-ui-1.0.0-alpha.7.tgz#5755adabe6c39b08e43d1cb8f603f9b0193aae08"
+  integrity sha512-iZ3Y8rkI9dcPgeSV9RXP9+L2/6UH2h4avr/5RFJ1BQoldGcr71b78sp6xWEvfTmle39nBrzPFCgFrLuEBqZ1FQ==
   dependencies:
-    "@expo/styleguide" "^8.1.0"
+    "@expo/styleguide" "^8.1.1"
     "@expo/styleguide-icons" "^1.0.3"
     cmdk "^0.2.0"
     lodash.groupby "^4.6.0"
 
 "@expo/styleguide@latest":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.1.0.tgz#3a0b0cac8da6058078178e854aeda01702a00f2a"
-  integrity sha512-OHwYiGvVg9R+sE7TTmEHrv7QUVTx7jKzDw4//Kl94H6G3RxvhVNK/ZL/QI13Tkb/wYwNE25FEjAhVB5WrBsLOg==
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.1.1.tgz#d494c56d79d3b757c7aa34839a8f87d7d73dea8e"
+  integrity sha512-sYnV3wu3fDTWabVKb9gAUxsjT+JqNaVt8JvJTRb+oTQ8lm3DPN5w+DypB0rTpdkgZlZBx7xnhWaiwqiMWHjXbQ==
   dependencies:
     "@expo/styleguide-base" "^1.0.1"
     tailwind-merge "^1.13.2"


### PR DESCRIPTION
# Why

While adding a library that modifies the HTML element class I have spotted that Tailwind `dark:` scope styles stops to apply, when there is an another class added.

# How

Correct the Tailwind config dark mode matcher by loosening check.