### PR TITLE
minor tweak and fixes for packages

### DIFF
--- a/packages/styleguide-icons/mergeClasses.ts
+++ b/packages/styleguide-icons/mergeClasses.ts
@@ -1,7 +1,11 @@
 import { extendTailwindMerge } from 'tailwind-merge';
 
-export const mergeClasses = extendTailwindMerge({
-  classGroups: {
-    icon: [{ icon: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
+type AdditionalClassGroupIds = 'icon';
+
+export const mergeClasses = extendTailwindMerge<AdditionalClassGroupIds>({
+  extend: {
+    classGroups: {
+      icon: [{ icon: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
+    },
   },
 });

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -171,7 +171,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
     const isRightSlotIcon = rightSlot && isIconElement(rightSlot);
     const iconClasses =
       (isLeftSlotIcon || isRightSlotIcon) &&
-      mergeClasses(`${getIconSizeClasses(size)}`, getThemedIconClasses(theme), disabled && 'opacity-60');
+      mergeClasses(getIconSizeClasses(size), getThemedIconClasses(theme), disabled && 'opacity-60');
     const isSingleIconButton = (leftSlot || rightSlot) && !children;
 
     const twClasses = mergeClasses(

--- a/packages/styleguide/src/helpers/mergeClasses.ts
+++ b/packages/styleguide/src/helpers/mergeClasses.ts
@@ -3,7 +3,7 @@ import { extendTailwindMerge } from 'tailwind-merge';
 type AdditionalClassGroupIds = 'icon';
 
 export const mergeClasses = extendTailwindMerge<AdditionalClassGroupIds>({
-  override: {
+  extend: {
     classGroups: {
       icon: [{ icon: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
     },

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -368,6 +368,9 @@ const expoTailwindConfig = {
       width: {
         15: '3.75rem',
       },
+      size: {
+        15: '3.75rem',
+      },
       opacity: {
         inherit: 'inherit',
       },
@@ -376,6 +379,16 @@ const expoTailwindConfig = {
         1025: '1.025',
         175: '1.75',
         200: '2.0',
+      },
+      fontSize: {
+        inherit: [
+          'inherit',
+          {
+            lineHeight: 'inherit',
+            letterSpacing: 'inherit',
+            fontWeight: 'inherit',
+          },
+        ],
       },
       gridTemplateColumns: {
         'auto-min-1': 'auto',
@@ -446,6 +459,15 @@ const expoTailwindConfig = {
         '.transform-box': { 'transform-box': 'fill-box' },
         '.backface-hidden': {
           'backface-visibility': 'hidden',
+        },
+        '.variant-numeric-normal': {
+          'font-variant-numeric': 'normal',
+        },
+        '.variant-numeric-slashed': {
+          'font-variant-numeric': 'slashed-zero',
+        },
+        '.variant-numeric-tubular': {
+          'font-variant-numeric': 'tabular-nums',
         },
       });
     }),


### PR DESCRIPTION
# Changelog

* [styleguide-icons] fix Tailwind merge config
* [styleguide] extend default Tailwind config

# Why

Looks like small regression slip through, when updating to new `tailwind-merge` version, which caused icon components issue, where the default size class ws not removed correctly, when use provide a custom one.

The Tailwind. config extension ports the custom classes uses in other projects, to make them generally available across all apps. I have also added a missing custom `size`, which custom variant we had for width and height already.