### PR TITLE
[styleguide] add an ability to skip Next Link usage

### DIFF
--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@expo/styleguide": "link:../styleguide",
     "@expo/styleguide-icons": "latest",
-    "@expo/styleguide-search-ui": "link:../search-ui",
+    "@expo/styleguide-search-ui": "latest",
     "@types/node": "^18.18.9",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -9,9 +9,9 @@
     "clean": "rimraf .next"
   },
   "dependencies": {
-    "@expo/styleguide": "latest",
+    "@expo/styleguide": "link:../styleguide",
     "@expo/styleguide-icons": "latest",
-    "@expo/styleguide-search-ui": "latest",
+    "@expo/styleguide-search-ui": "link:../search-ui",
     "@types/node": "^18.18.9",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf .next"
   },
   "dependencies": {
-    "@expo/styleguide": "link:../styleguide",
+    "@expo/styleguide": "latest",
     "@expo/styleguide-icons": "latest",
     "@expo/styleguide-search-ui": "latest",
     "@types/node": "^18.18.9",

--- a/packages/example-web/pages/ui/components.tsx
+++ b/packages/example-web/pages/ui/components.tsx
@@ -43,6 +43,11 @@ export default function ComponentsPage() {
       <DemoTile title="no href">
         <LinkBase>LinkBase</LinkBase>
       </DemoTile>
+      <DemoTile title="skip intenral Next Link">
+        <LinkBase skipNextLink href="/">
+          LinkBase
+        </LinkBase>
+      </DemoTile>
       <H3>Link</H3>
       <DemoTile title="default link">
         <Link href="#">Link</Link>
@@ -86,6 +91,11 @@ export default function ComponentsPage() {
           openInNewTab
           theme="secondary-destructive">
           Delete
+        </Button>
+      </DemoTile>
+      <DemoTile title="skip Next Link version">
+        <Button skipNextLink href="/" theme="quaternary">
+          Home
         </Button>
       </DemoTile>
       <H3>Icon Buttons</H3>

--- a/packages/styleguide/src/components/Link/LinkBase.tsx
+++ b/packages/styleguide/src/components/Link/LinkBase.tsx
@@ -6,10 +6,11 @@ export type LinkBaseProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   testID?: string;
   openInNewTab?: boolean;
   disabled?: boolean;
+  skipNextLink?: boolean;
 };
 
 export const LinkBase = forwardRef<HTMLAnchorElement, LinkBaseProps>(
-  ({ children, testID, href, openInNewTab, onClick, target, disabled, rel, ...rest }, ref) => {
+  ({ children, testID, href, openInNewTab, onClick, target, disabled, skipNextLink, rel, ...rest }, ref) => {
     if (disabled) {
       return (
         <a ref={ref} data-testid={testID} {...rest}>
@@ -26,8 +27,10 @@ export const LinkBase = forwardRef<HTMLAnchorElement, LinkBaseProps>(
       );
     }
 
+    const Tag = skipNextLink ? 'a' : Link;
+
     return (
-      <Link
+      <Tag
         href={href}
         ref={ref}
         onClick={onClick}
@@ -36,7 +39,7 @@ export const LinkBase = forwardRef<HTMLAnchorElement, LinkBaseProps>(
         data-testid={testID}
         {...rest}>
         {children}
-      </Link>
+      </Tag>
     );
   }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,8 +246,10 @@
   dependencies:
     tailwind-merge "^2.2.0"
 
-"@expo/styleguide-search-ui@link:packages/search-ui":
+"@expo/styleguide-search-ui@latest":
   version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-search-ui/-/styleguide-search-ui-1.0.2.tgz#e07cfa14161c74a6d89c0dc5e8897e053d6d54e7"
+  integrity sha512-V+ec5E3gnxZc13TuG5xV7C7WP3wr86kuZw+kZgbgf4IAgEgadlnoMjAtbtckN8r/KeYuT2FBsZR+9PVu4Lr1iw==
   dependencies:
     "@expo/styleguide" "^8.2.1"
     "@expo/styleguide-icons" "^1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,8 +256,10 @@
     cmdk "^0.2.0"
     lodash.groupby "^4.6.0"
 
-"@expo/styleguide@link:packages/styleguide":
+"@expo/styleguide@latest":
   version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.2.1.tgz#5ce3d3adecbf0ff868d8c1276126b29d4a98a75a"
+  integrity sha512-kKBhuKjhv/6caOdWpI//sGDyT5zpQWcxXR1TwH/81uFyLCYZGqxURXRyIJR/aZeGn+jK03vtmyUvBCT6uG013g==
   dependencies:
     "@expo/styleguide-base" "^1.0.1"
     tailwind-merge "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,20 +246,16 @@
   dependencies:
     tailwind-merge "^2.2.0"
 
-"@expo/styleguide-search-ui@latest":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-search-ui/-/styleguide-search-ui-1.0.0.tgz#110192e77ccd0c9ee0e19b9e3594bdaef8d3f0b0"
-  integrity sha512-bd0iVSThly32uVBLqa4W0r12F3Me8DhBMmre2noCX4ekpaQchv8BTQBzIXDFWRQGBop/BccTxQcsG839fV4D+Q==
+"@expo/styleguide-search-ui@link:packages/search-ui":
+  version "1.0.2"
   dependencies:
-    "@expo/styleguide" "^8.2.0"
-    "@expo/styleguide-icons" "^1.0.6"
+    "@expo/styleguide" "^8.2.1"
+    "@expo/styleguide-icons" "^1.0.7"
     cmdk "^0.2.0"
     lodash.groupby "^4.6.0"
 
-"@expo/styleguide@latest":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.2.0.tgz#52ae72d2cc5a8b274ac138afabf1e2501f17009e"
-  integrity sha512-GPOZ0vrBNGTsa9i2GKcxNGm3rRcU830rZRgH/yQrp8NWS+ZC26R/7u4+Y1IVBrSbfRgMlW63a46mYkz/I+f0eg==
+"@expo/styleguide@link:packages/styleguide":
+  version "8.2.1"
   dependencies:
     "@expo/styleguide-base" "^1.0.1"
     tailwind-merge "^2.2.0"


### PR DESCRIPTION
# Why

There are few, edge cases when it's unwanted to use Next Link component at all.

# How

This PR adds a prop which allows Styleguide users to decide if they want to relay on raw HTML `a` tag instead.

Changes have been applied for `LinkBase` which is a building block of other intractable components. The dedicated tests have been added to web example app.