### PR TITLE
[workspace] update Tailwind and merge helper, list semantic colors

### DIFF
--- a/packages/example-web/components/headers.tsx
+++ b/packages/example-web/components/headers.tsx
@@ -20,13 +20,28 @@ export function H3({ children, className, ...rest }: HTMLAttributes<HTMLHeadingE
   return (
     <h3
       className={mergeClasses(
-        'heading-3xl font-bold mt-10 mb-4 scroll-mt-5 truncate ',
+        'heading-3xl font-bold mt-10 mb-4 scroll-mt-5 truncate',
         'max-md-gutters:heading-2xl',
-        ',max-sm-gutters:heading-xl',
+        'max-sm-gutters:heading-xl',
         className
       )}
       {...rest}>
       {children}
     </h3>
+  );
+}
+
+export function H4({ children, className, ...rest }: HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h4
+      className={mergeClasses(
+        'heading-lg font-semibold scroll-mt-5 mb-4 truncate',
+        'max-md-gutters:heading-2xl',
+        'max-sm-gutters:heading-xl',
+        className
+      )}
+      {...rest}>
+      {children}
+    </h4>
   );
 }

--- a/packages/example-web/data/styleguideEntries.ts
+++ b/packages/example-web/data/styleguideEntries.ts
@@ -3,6 +3,11 @@ import { BezierCurve03Icon, LayoutAlt03Icon, PaletteIcon, TextInputIcon, Type01I
 
 export const entries = [
   {
+    label: 'Colors: Semantic',
+    url: '/colors#semantic',
+    Icon: PaletteIcon,
+  },
+  {
     label: 'Colors: Palette',
     url: '/colors#palette',
     Icon: PaletteIcon,

--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -18,16 +18,16 @@
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tailwind-merge": "^2.2.0",
+    "tailwind-merge": "^2.3.0",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^14.0.4",
-    "@tailwindcss/typography": "^0.5.9",
+    "@tailwindcss/typography": "^0.5.10",
     "autoprefixer": "^10.4.16",
     "eslint-config-next": "^14.0.4",
     "postcss": "^8.4.32",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.4"
   },
   "eslintConfig": {
     "extends": ["universe/web", "next/core-web-vitals"],

--- a/packages/example-web/pages/colors.tsx
+++ b/packages/example-web/pages/colors.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 
 import { getPaletteClasses } from '@/common/utils';
-import { H1, H3 } from '@/components/headers';
+import { H1, H3, H4 } from '@/components/headers';
 import useCopy from '@/hooks/useCopy';
 
 export default function ColorsPage() {
@@ -9,6 +9,79 @@ export default function ColorsPage() {
   return (
     <>
       <H1>Colors</H1>
+      <H3 id="semantic">Semantic</H3>
+      <H4>Backgrounds</H4>
+      <div className="flex flex-wrap mb-2">
+        {[
+          'bg-default',
+          'bg-screen',
+          'bg-subtle',
+          'bg-element',
+          'bg-hover',
+          'bg-selected',
+          'bg-overlay',
+          'bg-success',
+          'bg-warning',
+          'bg-danger',
+          'bg-info',
+        ].map((className, index) => (
+          <div key={index}>
+            <div
+              className={mergeClasses(
+                'w-16 h-16 mb-1 transition',
+                'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                className
+              )}
+              onClick={() => copy(className)}
+            />
+            <p className="text-3xs text-secondary text-center">{className.replace('bg-', '')}</p>
+          </div>
+        ))}
+      </div>
+      <H4 className="mt-6">Borders</H4>
+      <div className="flex flex-wrap mb-2">
+        {['border-default', 'border-secondary', 'border-success', 'border-warning', 'border-danger', 'border-info'].map(
+          (className, index) => (
+            <div key={index}>
+              <div
+                className={mergeClasses(
+                  'w-16 h-16 mb-1 transition border-[10px]',
+                  'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                  className
+                )}
+                onClick={() => copy(className)}
+              />
+              <p className="text-3xs text-secondary text-center">{className.replace('border-', '')}</p>
+            </div>
+          )
+        )}
+      </div>
+      <H4 className="mt-6">Text colors</H4>
+      <div className="flex flex-wrap mb-2">
+        {[
+          'text-default',
+          'text-secondary',
+          'text-tertiary',
+          'text-quaternary',
+          'text-success',
+          'text-warning',
+          'text-danger',
+          'text-info',
+        ].map((className, index) => (
+          <div key={index}>
+            <div
+              className={mergeClasses(
+                'inline-flex items-center justify-center heading-xl w-16 h-16 mb-1 transition font-black',
+                'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                className
+              )}
+              onClick={() => copy(className)}>
+              T
+            </div>
+            <p className="text-3xs text-secondary text-center">{className.replace('text-', '')}</p>
+          </div>
+        ))}
+      </div>
       <H3 id="palette">Palette</H3>
       <div className="grid gap-2 mt-8">
         {['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink', 'gray'].map((color) => (

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/lodash.groupby": "^4.6.9",
-    "tailwindcss": "^3.4.0",
+    "tailwindcss": "^3.4.4",
     "user-agent-data-types": "^0.4.2"
   },
   "peerDependencies": {

--- a/packages/styleguide-icons/package.json
+++ b/packages/styleguide-icons/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/expo/styleguide/issues"
   },
   "dependencies": {
-    "tailwind-merge": "^2.2.0"
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@figma-export/cli": "^4.7.0",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@expo/styleguide-base": "^1.0.1",
-    "tailwind-merge": "^2.2.0"
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.4"
   },
   "peerDependencies": {
     "next": ">= 13",

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -128,6 +128,7 @@ const expoTailwindConfig = {
       warning: 'var(--expo-theme-background-warning)',
       danger: 'var(--expo-theme-background-danger)',
       info: 'var(--expo-theme-background-info)',
+      transparent: 'transparent',
 
       'button-primary': 'var(--expo-theme-button-primary-background)',
       'button-primary-hover': 'var(--expo-theme-button-primary-hover)',
@@ -332,9 +333,32 @@ const expoTailwindConfig = {
       'lg-gutters': '1008px',
       xl: '1200px',
       'xl-gutters': '1248px',
+      '2xl': '1524px',
+      '2xl-gutters': '1572px',
     },
     extend: {
       stroke: {
+        'bg-default': 'var(--expo-theme-background-default)',
+        'bg-screen': 'var(--expo-theme-background-screen)',
+        'bg-subtle': 'var(--expo-theme-background-subtle)',
+        'bg-element': 'var(--expo-theme-background-element)',
+        'bg-hover': 'var(--expo-theme-background-hover)',
+        'bg-selected': 'var(--expo-theme-background-selected)',
+        'bg-overlay': 'var(--expo-theme-background-overlay)',
+        'bg-success': 'var(--expo-theme-background-success)',
+        'bg-warning': 'var(--expo-theme-background-warning)',
+        'bg-danger': 'var(--expo-theme-background-danger)',
+        'bg-info': 'var(--expo-theme-background-info)',
+      },
+      fill: {
+        'border-default': 'var(--expo-theme-border-default)',
+        'border-secondary': 'var(--expo-theme-border-secondary)',
+        'border-success': 'var(--expo-theme-border-success)',
+        'border-warning': 'var(--expo-theme-border-warning)',
+        'border-danger': 'var(--expo-theme-border-danger)',
+        'border-info': 'var(--expo-theme-border-info)',
+      },
+      gradientColorStops: {
         'bg-default': 'var(--expo-theme-background-default)',
         'bg-screen': 'var(--expo-theme-background-screen)',
         'bg-subtle': 'var(--expo-theme-background-subtle)',
@@ -360,7 +384,6 @@ const expoTailwindConfig = {
         'app-lime': 'var(--expo-color-app-lime)',
         'app-light-green': 'var(--expo-color-app-light-green)',
         'app-dark-green': 'var(--expo-color-app-dark-green)',
-        transparent: 'transparent',
       },
       height: {
         15: '3.75rem',
@@ -466,7 +489,7 @@ const expoTailwindConfig = {
         '.variant-numeric-slashed': {
           'font-variant-numeric': 'slashed-zero',
         },
-        '.variant-numeric-tubular': {
+        '.variant-numeric-tabular': {
           'font-variant-numeric': 'tabular-nums',
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,10 +166,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.15.tgz#eec9f36d8eaf0948bb88c87a46784b5ee9fd0c89"
   integrity sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==
 
-"@babel/runtime@^7.13.10", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.5":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
-  integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.23.2", "@babel/runtime@^7.24.1":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.7.tgz#f4f0d5530e8dbdf59b3451b9b3e594b6ba082e12"
+  integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -1237,7 +1237,7 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tailwindcss/typography@^0.5.10", "@tailwindcss/typography@^0.5.9":
+"@tailwindcss/typography@^0.5.10":
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.10.tgz#2abde4c6d5c797ab49cf47610830a301de4c1e0a"
   integrity sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==
@@ -4354,10 +4354,10 @@ jest-get-type@^29.6.3:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
-jiti@^1.19.1:
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
-  integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
+jiti@^1.21.0:
+  version "1.21.6"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
+  integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6832,17 +6832,17 @@ synckit@^0.8.4, synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
-tailwind-merge@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.2.0.tgz#b6bb1c63ef26283c9e6675ba237df83bbd554688"
-  integrity sha512-SqqhhaL0T06SW59+JVNfAqKdqLs0497esifRrZ7jOaefP3o64fdFNDMrAQWZFMxTLJPiHVjRLUywT8uFz1xNWQ==
+tailwind-merge@^2.2.0, tailwind-merge@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.3.0.tgz#27d2134fd00a1f77eca22bcaafdd67055917d286"
+  integrity sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==
   dependencies:
-    "@babel/runtime" "^7.23.5"
+    "@babel/runtime" "^7.24.1"
 
-tailwindcss@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.0.tgz#045a9c474e6885ebd0436354e611a76af1c76839"
-  integrity sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==
+tailwindcss@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.4.tgz#351d932273e6abfa75ce7d226b5bf3a6cb257c05"
+  integrity sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     arg "^5.0.2"
@@ -6852,7 +6852,7 @@ tailwindcss@^3.4.0:
     fast-glob "^3.3.0"
     glob-parent "^6.0.2"
     is-glob "^4.0.3"
-    jiti "^1.19.1"
+    jiti "^1.21.0"
     lilconfig "^2.1.0"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"


### PR DESCRIPTION
# Why

The latest version of Tailwind and `tailwind-merge` includes fixes which we would like to have upstream.

# How

* Update `taliwindcss` and `tailwind-merge` dependencies to the latest releases
* Add missing fill and gradient colors
* Align `@tailwindcss/typography` package version
* List semantic color on the Colors page of Styleguide example app

# Preview

![Screenshot 2024-06-13 at 11 44 26](https://github.com/expo/styleguide/assets/719641/ab86a8cd-4e9d-4ea4-8b76-7ed37c98cf29)
![Screenshot 2024-06-13 at 11 44 20](https://github.com/expo/styleguide/assets/719641/dd6ca7e4-6e76-4322-8ac3-af7201a701f0)
