### PR TITLE
[styleguide] fix up the Tailwind theme gradient stops

### DIFF
--- a/packages/example-web/pages/_app.tsx
+++ b/packages/example-web/pages/_app.tsx
@@ -50,6 +50,8 @@ export default function App({ Component, pageProps }: AppProps) {
         </Head>
         <main
           className={mergeClasses(
+            'bg-gradient-to-b from-subtle to-default',
+            'dark:from-default dark:to-screen',
             'grid grid-cols-[240px_1fr] p-8 gap-8 min-h-dvh',
             'max-md-gutters:grid-cols-[140px_1fr]',
             'max-sm-gutters:grid-cols-1 max-sm-gutters:gap-16'

--- a/packages/example-web/pages/colors.tsx
+++ b/packages/example-web/pages/colors.tsx
@@ -29,7 +29,8 @@ export default function ColorsPage() {
             <div
               className={mergeClasses(
                 'w-16 h-16 mb-1 transition',
-                'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                'active:scale-105',
                 className
               )}
               onClick={() => copy(className)}
@@ -46,7 +47,8 @@ export default function ColorsPage() {
               <div
                 className={mergeClasses(
                   'w-16 h-16 mb-1 transition border-[10px]',
-                  'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                  'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                  'active:scale-105',
                   className
                 )}
                 onClick={() => copy(className)}
@@ -72,7 +74,8 @@ export default function ColorsPage() {
             <div
               className={mergeClasses(
                 'inline-flex items-center justify-center heading-xl w-16 h-16 mb-1 transition font-black',
-                'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                'active:scale-105',
                 className
               )}
               onClick={() => copy(className)}>
@@ -91,7 +94,8 @@ export default function ColorsPage() {
                 <div
                   className={mergeClasses(
                     'w-16 h-16 mb-1 transition',
-                    'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                    'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                    'active:scale-105',
                     className
                   )}
                   onClick={() => copy(`palette-${color}${index + 1}`)}
@@ -125,7 +129,8 @@ export default function ColorsPage() {
             <div
               className={mergeClasses(
                 'w-16 h-16 mb-1 transition',
-                'hover:scale-110 hover:shadow-md hover:cursor-pointer active:scale-105',
+                'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                'active:scale-105',
                 className
               )}
               onClick={() => copy(className)}

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -227,6 +227,22 @@ const expoTailwindConfig = {
 
       ...palette,
     },
+    gradientColorStops: {
+      default: 'var(--expo-theme-background-default)',
+      screen: 'var(--expo-theme-background-screen)',
+      subtle: 'var(--expo-theme-background-subtle)',
+      element: 'var(--expo-theme-background-element)',
+      hover: 'var(--expo-theme-background-hover)',
+      selected: 'var(--expo-theme-background-selected)',
+      overlay: 'var(--expo-theme-background-overlay)',
+      success: 'var(--expo-theme-background-success)',
+      warning: 'var(--expo-theme-background-warning)',
+      danger: 'var(--expo-theme-background-danger)',
+      info: 'var(--expo-theme-background-info)',
+      transparent: 'transparent',
+
+      ...palette,
+    },
     boxShadow: {
       none: 'var(--expo-theme-shadows-none)',
       xs: 'var(--expo-theme-shadows-xs)',
@@ -357,19 +373,6 @@ const expoTailwindConfig = {
         'border-warning': 'var(--expo-theme-border-warning)',
         'border-danger': 'var(--expo-theme-border-danger)',
         'border-info': 'var(--expo-theme-border-info)',
-      },
-      gradientColorStops: {
-        'bg-default': 'var(--expo-theme-background-default)',
-        'bg-screen': 'var(--expo-theme-background-screen)',
-        'bg-subtle': 'var(--expo-theme-background-subtle)',
-        'bg-element': 'var(--expo-theme-background-element)',
-        'bg-hover': 'var(--expo-theme-background-hover)',
-        'bg-selected': 'var(--expo-theme-background-selected)',
-        'bg-overlay': 'var(--expo-theme-background-overlay)',
-        'bg-success': 'var(--expo-theme-background-success)',
-        'bg-warning': 'var(--expo-theme-background-warning)',
-        'bg-danger': 'var(--expo-theme-background-danger)',
-        'bg-info': 'var(--expo-theme-background-info)',
       },
       backgroundColor: {
         'app-cyan': 'var(--expo-color-app-cyan)',


### PR DESCRIPTION
# Why & How

Instead of extending, overwrite the `gradientColorStops` definitions in Tailwind theme, don't use `bg-` prefix for semantic colors.

The changes have been tested with locally updated package used inside `example-web` app.

# Preview

![Screenshot 2024-08-05 at 20 05 55](https://github.com/user-attachments/assets/af7b35e2-8289-4035-b61e-3ad137665cfd)
