### PR TITLE
[styleguide] move-in commonly used Tailwind theme extensions

### DIFF
--- a/packages/example-web/components/Sidebar.tsx
+++ b/packages/example-web/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar() {
           'flex flex-col gap-5',
           'max-sm-gutters:items-center max-sm-gutters:flex-row max-sm-gutters:mb-5'
         )}>
-        <Link href="/">
+        <Link href="/" className="animate-fadeIn">
           <Image src="/icon.png" width="72" height="72" alt="Expo Styleguide Logo" className="max-sm-gutters:hidden" />
           <Image
             src="/icon.png"

--- a/packages/example-web/merge-icon-imports.js
+++ b/packages/example-web/merge-icon-imports.js
@@ -1,7 +1,8 @@
 // Since removal of barrel files from the @expo/styleguide-icons, in order to
 // display all icons we are automatically generating a file with all exports on
 // the side of example-web.
-const fs = require('fs');
+const fs = require('node:fs');
+const { join } = require('node:path');
 
 const base = './node_modules/@expo/styleguide-icons';
 const dirs = ['custom', 'duotone', 'outline', 'solid'];
@@ -10,15 +11,21 @@ async function run() {
   const files = [
     ...(await Promise.all(
       dirs.map((directory) =>
-        fs.promises.readdir(`${base}/${directory}`).then((files) =>
-          files
-            .filter((file) => file.endsWith('.js'))
-            .filter((file) => !file.startsWith('index'))
-            .map((file) => {
-              const iconName = file.replaceAll('.js', '').split('/').at(-1);
-              return `export { ${iconName} } from '@expo/styleguide-icons/${directory}/${iconName}'`;
-            })
-        )
+        fs.promises
+          .readdir(join(base, directory))
+          .catch((error) => {
+            console.error(error.message);
+            process.exit(1);
+          })
+          .then((files) =>
+            files
+              .filter((file) => file.endsWith('.js'))
+              .filter((file) => !file.startsWith('index'))
+              .map((file) => {
+                const iconName = file.replaceAll('.js', '').split('/').at(-1);
+                return `export { ${iconName} } from '@expo/styleguide-icons/${directory}/${iconName}'`;
+              })
+          )
       )
     )),
   ].flat();

--- a/packages/example-web/pages/icons.tsx
+++ b/packages/example-web/pages/icons.tsx
@@ -14,10 +14,10 @@ import { PlaceholderIcon } from '@expo/styleguide-icons/outline/PlaceholderIcon'
 import { SearchMdIcon } from '@expo/styleguide-icons/outline/SearchMdIcon';
 import { createElement, useState } from 'react';
 
-import * as StyleguideIcons from '../common/icon-imports';
-
 import { H1, H3 } from '@/components/headers';
 import useCopy from '@/hooks/useCopy';
+
+import * as StyleguideIcons from '../common/icon-imports';
 
 type IconNames = keyof typeof StyleguideIcons;
 

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -429,6 +429,72 @@ const expoTailwindConfig = {
       transitionDuration: {
         default: '150ms',
       },
+      keyframes: {
+        fadeIn: {
+          '0%': {
+            opacity: 0,
+          },
+          '100%': {
+            opacity: 1,
+          },
+        },
+        fadeOut: {
+          '0%': {
+            opacity: 1,
+          },
+          '100%': {
+            opacity: 0,
+          },
+        },
+        slideDownAndFade: {
+          '0%': {
+            opacity: 0,
+            transform: 'translateY(8px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateY(0)',
+          },
+        },
+        slideRightAndFade: {
+          '0%': {
+            opacity: 0,
+            transform: 'translateX(8px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateX(0)',
+          },
+        },
+        slideLeftAndFade: {
+          '0%': {
+            opacity: 0,
+            transform: 'translateX(-8px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateX(0)',
+          },
+        },
+        slideUpAndFade: {
+          '0%': {
+            opacity: 0,
+            transform: 'translateY(-8px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateY(0)',
+          },
+        },
+      },
+      animation: {
+        fadeIn: 'fadeIn 0.25s ease-out',
+        fadeOut: 'fadeOut 0.15s ease-in',
+        slideDownAndFade: 'slideDownAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+        slideRightAndFade: 'slideRightAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+        slideLeftAndFade: 'slideLeftAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+        slideUpAndFade: 'slideUpAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+      },
       typography: () => ({
         DEFAULT: {
           css: {
@@ -481,6 +547,7 @@ const expoTailwindConfig = {
           width: theme('width.10'),
         },
         '.break-words': { 'word-break': 'break-word' },
+        '.wrap-anywhere': { 'overflow-wrap': 'anywhere' },
         '.pause-animation': { 'animation-play-state': 'paused' },
         '.transform-box': { 'transform-box': 'fill-box' },
         '.backface-hidden': {
@@ -494,6 +561,12 @@ const expoTailwindConfig = {
         },
         '.variant-numeric-tabular': {
           'font-variant-numeric': 'tabular-nums',
+        },
+        '.asset-shadow': {
+          filter: 'drop-shadow(0 3px 10px rgba(0, 0, 0, 0.12)) drop-shadow(0 2px 6px rgba(0, 0, 0, 0.07))',
+        },
+        '.asset-sm-shadow': {
+          filter: 'drop-shadow(0 2px 8px rgba(0, 0, 0, 0.08)) drop-shadow(0 1px 4px rgba(0, 0, 0, 0.03))',
         },
       });
     }),


### PR DESCRIPTION
# Why & how

Move-in commonly used Tailwind theme extensions across our apps to avoid the definition repetition. The list includes asset shadows (very blurry, commonly used when presenting images or graphs) and base set of animations and their animations.

The Tailwind theme changes have been tested using the build-in example-web app, which now includes subtle load animation to make sure that theme definitions are working correctly.

I have also added a more gracefully way to fail when directories listed in `merge-icons-imports` script does not exist, and fixed the hardcoded path, since it was causing some issues when running on Windows.

# Preview

https://github.com/user-attachments/assets/2de9bc72-9c20-41b0-83cb-240942dd7f4d
