### PR TITLE
[search-ui] add Expo Blog posts section

### DIFF
--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -30,6 +30,8 @@
   "dependencies": {
     "@expo/styleguide": "^8.2.5",
     "@expo/styleguide-icons": "^2.0.0",
+    "@sanity/client": "^6.21.3",
+    "@sanity/image-url": "^1.0.2",
     "cmdk": "^0.2.1",
     "lodash.groupby": "^4.6.0"
   },

--- a/packages/search-ui/rollup.config.mjs
+++ b/packages/search-ui/rollup.config.mjs
@@ -22,6 +22,8 @@ const config = [
       '@expo/styleguide',
       '@expo/styleguide-base',
       '@expo/styleguide-icons',
+      '@sanity/client',
+      '@sanity/image-url',
       'cmdk',
       'lodash.groupby',
       'react',

--- a/packages/search-ui/src/Items/ExpoBlogItem.tsx
+++ b/packages/search-ui/src/Items/ExpoBlogItem.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { ExternalLinkIcon } from './icons';
+import { CommandItemBaseWithCopy } from '../components/CommandItemBaseWithCopy';
+import { addHighlight, getSanityAsset } from '../utils';
+import { ExpoBlogItemType } from '../types';
+
+type Props = {
+  item: ExpoBlogItemType;
+  query: string;
+  onSelect?: () => void;
+};
+
+export const ExpoBlogItem = ({ item, onSelect, query }: Props) => {
+  return (
+    <CommandItemBaseWithCopy
+      value={`expo-blog-${item.slug.current}`}
+      url={`https://expo.dev/blog/${item.slug.current}`}
+      isExternalLink
+      onSelect={onSelect}
+    >
+      <div className="inline-flex gap-3 items-center">
+        <img
+          src={getSanityAsset(item.mainImage.image.asset._ref)}
+          alt={item.mainImage.altText}
+          className="size-11 object-cover rounded-md my-0.5"
+        />
+        <div>
+          <p className="text-xs font-medium" dangerouslySetInnerHTML={{ __html: addHighlight(item.title, query) }} />
+          <p className="text-3xs text-quaternary" dangerouslySetInnerHTML={{ __html: addHighlight(item.metadataDescription, query) }} />
+        </div>
+        <ExternalLinkIcon />
+      </div>
+    </CommandItemBaseWithCopy>
+  );
+};

--- a/packages/search-ui/src/components/CommandMenu.tsx
+++ b/packages/search-ui/src/components/CommandMenu.tsx
@@ -8,7 +8,16 @@ import { BarLoader } from './BarLoader';
 import { CommandFooter } from './CommandFooter';
 import { RNDirectoryItem, RNDocsItem, ExpoDocsItem } from '../Items';
 import type { RNDirectoryItemType, AlgoliaItemType, CommandMenuConfig, CommandMenuSection } from '../types';
-import { getExpoDocsResults, getRNDocsResults, getDirectoryResults, getItemsAsync, isAppleDevice } from '../utils';
+import {
+  getExpoDocsResults,
+  getRNDocsResults,
+  getDirectoryResults,
+  getItemsAsync,
+  isAppleDevice,
+  getExpoBlogResults, getSanityItemsAsync,
+} from '../utils';
+import { ExpoBlogItem } from '../Items/ExpoBlogItem';
+import { ExpoBlogItemType } from '../types';
 
 type Props = {
   open: boolean;
@@ -29,10 +38,12 @@ export const CommandMenu = ({
   const [isMac, setIsMac] = useState<boolean | null>(null);
 
   const [expoDocsItems, setExpoDocsItems] = useState<AlgoliaItemType[]>([]);
+  const [expoBlogItems, setExpoBlogItems] = useState<ExpoBlogItemType[]>([]);
   const [rnDocsItems, setRnDocsItems] = useState<AlgoliaItemType[]>([]);
   const [directoryItems, setDirectoryItems] = useState<RNDirectoryItemType[]>([]);
 
   const getExpoDocsItems = async () => getItemsAsync(query, getExpoDocsResults, setExpoDocsItems, docsVersion);
+  const getExpoBlogItems = async () => getSanityItemsAsync(query, getExpoBlogResults, setExpoBlogItems);
   const getRNDocsItems = async () => getItemsAsync(query, getRNDocsResults, setRnDocsItems);
   const getDirectoryItems = async () => getItemsAsync(query, getDirectoryResults, setDirectoryItems);
 
@@ -41,9 +52,10 @@ export const CommandMenu = ({
   const fetchData = (callback: () => void) => {
     Promise.all([
       getExpoDocsItems(),
+      getExpoBlogItems(),
       getRNDocsItems(),
       getDirectoryItems(),
-      ...customSections.map((section) => section.getItemsAsync(query)),
+      ...customSections?.map((section) => section.getItemsAsync(query)),
     ]).then(callback);
   };
 
@@ -109,6 +121,13 @@ export const CommandMenu = ({
               />
             ))
         )}
+      </Command.Group>
+    ),
+    expoBlogItems.length > 0 && (
+      <Command.Group heading="Expo blog" key="expo-blog-group">
+        {expoBlogItems.map((item) => (
+          <ExpoBlogItem item={item} onSelect={dismiss} key={`hit-expo-blog-${item.slug.current}`} query={query} />
+        ))}
       </Command.Group>
     ),
     rnDocsItems.length > 0 && (

--- a/packages/search-ui/src/types.ts
+++ b/packages/search-ui/src/types.ts
@@ -51,3 +51,20 @@ export type RNDirectoryItemType = {
     };
   };
 };
+
+export type ExpoBlogItemType = {
+  title: string;
+  tags: string[];
+  metadataDescription: string;
+  slug: {
+    current: string;
+  };
+  mainImage: {
+    altText: string;
+    image: {
+      asset: {
+        _ref: string;
+      };
+    };
+  };
+};

--- a/packages/search-ui/src/utils.ts
+++ b/packages/search-ui/src/utils.ts
@@ -1,10 +1,10 @@
 /// <reference types="user-agent-data-types" />
 
+import { ClientReturn, createClient } from '@sanity/client';
+import imageUrlBuilder from '@sanity/image-url';
 import type { Dispatch, SetStateAction } from 'react';
 
 import type { AlgoliaItemHierarchy, AlgoliaItemType } from './types';
-import { ClientReturn, createClient } from '@sanity/client';
-import imageUrlBuilder from '@sanity/image-url'
 
 export const SANITY_CLIENT = createClient({
   projectId: 'siias52v',
@@ -78,7 +78,15 @@ export const getRNDocsResults = (query: string) => {
 };
 
 export const getExpoBlogResults = (query: string) => {
-  return SANITY_CLIENT.fetch(`*[_type == "post" && title match "${query}*"] | order(publishAt desc)[0...10] { title, slug, tags, metadataDescription, mainImage }`);
+  return SANITY_CLIENT.fetch(
+    `*[_type == "post" && (title match "${query}*" || metadataDescription match "${query}*")] | order(publishAt desc)[0...10] {
+      title,
+      slug,
+      tags,
+      metadataDescription,
+      mainImage
+    }`
+  );
 };
 
 export const getDirectoryResults = (query: string) => {

--- a/packages/search-ui/src/utils.ts
+++ b/packages/search-ui/src/utils.ts
@@ -16,7 +16,7 @@ export const SANITY_CLIENT = createClient({
 const sanityAssetHelper = imageUrlBuilder({ projectId: 'siias52v', dataset: 'production' });
 
 export function getSanityAsset(source: string) {
-  return sanityAssetHelper.image(source).url();
+  return sanityAssetHelper.image(source).auto('format').height(150).url();
 }
 
 export const getItemsAsync = async <T>(

--- a/packages/search-ui/tsconfig.json
+++ b/packages/search-ui/tsconfig.json
@@ -5,6 +5,7 @@
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
+    "target": "ES2021",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "declaration": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,30 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz#5f1b518ec5fa54437c0b7c4a821546c64fed6922"
   integrity sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==
 
+"@sanity/client@^6.21.3":
+  version "6.21.3"
+  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-6.21.3.tgz#f08302843c46464cb964270441c544a9ab75af6d"
+  integrity sha512-oE2+4kKRTZhFCc4IIsojkzKF0jIhsSYSRxkPZjScZ1k/EQ3Y2tEcQYiKwvvotzaXoaWsIL3RTpulE+R4iBYiBw==
+  dependencies:
+    "@sanity/eventsource" "^5.0.2"
+    get-it "^8.6.4"
+    rxjs "^7.0.0"
+
+"@sanity/eventsource@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@sanity/eventsource/-/eventsource-5.0.2.tgz#0124214e92122149a2f0357fb40b9f7112924ad9"
+  integrity sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==
+  dependencies:
+    "@types/event-source-polyfill" "1.0.5"
+    "@types/eventsource" "1.1.15"
+    event-source-polyfill "1.0.31"
+    eventsource "2.0.2"
+
+"@sanity/image-url@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.2.tgz#1ff7259e9bad6bfca4169f21c53a4123f6ac78c3"
+  integrity sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ==
+
 "@sigstore/bundle@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.3.2.tgz#ad4dbb95d665405fd4a7a02c8a073dbd01e4e95e"
@@ -1476,6 +1500,23 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/event-source-polyfill@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz#7223387b99ff519b0fed6278961c84315ffc14b7"
+  integrity sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==
+
+"@types/eventsource@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-1.1.15.tgz#949383d3482e20557cbecbf3b038368d94b6be27"
+  integrity sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==
+
+"@types/follow-redirects@^1.14.4":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@types/follow-redirects/-/follow-redirects-1.14.4.tgz#ca054d72ef574c77949fc5fff278b430fcd508ec"
+  integrity sha512-GWXfsD0Jc1RWiFmMuMFCpXMzi9L7oPDVwxUnZdg89kDNnqsRfUKXEtUYtA98A6lig1WXH/CYY/fvPW9HuN5fTA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/fs-extra@^8.0.1":
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.2.tgz#7125cc2e4bdd9bd2fc83005ffdb1d0ba00cca61f"
@@ -1539,6 +1580,13 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/progress-stream@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/progress-stream/-/progress-stream-2.0.5.tgz#50f10be88b0717c8fce6573e7fcafa8eabbc3dcf"
+  integrity sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -2359,7 +2407,7 @@ cmd-shim@6.0.3, cmd-shim@^6.0.0:
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-6.0.3.tgz#c491e9656594ba17ac83c4bd931590a9d6e26033"
   integrity sha512-FMabTRlc5t5zjdenF6mS0MBeFZm0XqHqeOkcskKFb/LYCcRQ5fVgLOHVc4Lq9CqABd9zhjwPjMBCJvMCziSVtA==
 
-cmdk@^0.2.0, cmdk@^0.2.1:
+cmdk@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-0.2.1.tgz#aa8e1332bb0b8d8484e793017c82537351188d9a"
   integrity sha512-U6//9lQ6JvT47+6OF6Gi8BvkxYQ8SCRRSKIJkthIMsFsLZRG0cKvTtuTaefyIKMQb8rvvXy0wGdpTNq/jPtm+g==
@@ -2722,6 +2770,13 @@ decamelize@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decompress-response@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-7.0.0.tgz#dc42107cc29a258aa8983fddc81c92351810f6fb"
+  integrity sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==
+  dependencies:
+    mimic-response "^3.1.0"
 
 dedent@1.5.3:
   version "1.5.3"
@@ -3404,10 +3459,20 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-source-polyfill@1.0.31:
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz#45fb0a6fc1375b2ba597361ba4287ffec5bf2e0c"
+  integrity sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==
+
 eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+eventsource@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
 
 execa@5.0.0:
   version "5.0.0"
@@ -3680,6 +3745,19 @@ get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-it@^8.6.4:
+  version "8.6.5"
+  resolved "https://registry.yarnpkg.com/get-it/-/get-it-8.6.5.tgz#69c85fa215707315861a32733738b578d0f8e640"
+  integrity sha512-o1hjPwrb/icm3WJbCweTSq8mKuDfJlqwbFauI+Pdgid99at/BFaBXFBJZE+uqvHyOVARE4z680S44vrDm8SsCw==
+  dependencies:
+    "@types/follow-redirects" "^1.14.4"
+    "@types/progress-stream" "^2.0.5"
+    decompress-response "^7.0.0"
+    follow-redirects "^1.15.6"
+    is-retry-allowed "^2.2.0"
+    progress-stream "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 get-nonce@^1.0.0:
   version "1.0.1"
@@ -4363,6 +4441,11 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
+
 is-set@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
@@ -5004,6 +5087,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -6025,6 +6113,14 @@ proggy@^2.0.0:
   resolved "https://registry.yarnpkg.com/proggy/-/proggy-2.0.0.tgz#154bb0e41d3125b518ef6c79782455c2c47d94e1"
   integrity sha512-69agxLtnI8xBs9gUGqEnK26UfiexpHy+KUpBQWabiytQjnn5wFY8rklAi7GRfABIuPNnQ/ik48+LGLkYYJcy4A==
 
+progress-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress-stream/-/progress-stream-2.0.0.tgz#fac63a0b3d11deacbb0969abcc93b214bce19ed5"
+  integrity sha512-xJwOWR46jcXUq6EH9yYyqp+I52skPySOeHfkxOZ2IY1AiBi/sFJhbhAKHoV3OTw/omQ45KTio9215dRJ2Yxd3Q==
+  dependencies:
+    speedometer "~1.0.0"
+    through2 "~2.0.3"
+
 promise-all-reject-late@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz#f8ebf13483e5ca91ad809ccc2fcf25f26f8643c2"
@@ -6428,10 +6524,10 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.5.5:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
-  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
+rxjs@^7.0.0, rxjs@^7.5.5:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
   dependencies:
     tslib "^2.1.0"
 
@@ -6452,7 +6548,7 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -6696,6 +6792,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
   integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
+
+speedometer@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-1.0.0.tgz#cd671cb06752c22bca3370e2f334440be4fc62e2"
+  integrity sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==
 
 split2@^3.2.2:
   version "3.2.2"
@@ -6967,7 +7068,7 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
-tailwind-merge@^2.3.0, tailwind-merge@^2.5.2:
+tailwind-merge@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.5.2.tgz#000f05a703058f9f9f3829c644235f81d4c08a1f"
   integrity sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==
@@ -7067,7 +7168,7 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -7176,6 +7277,13 @@ tuf-js@^2.2.1:
     "@tufjs/models" "2.0.1"
     debug "^4.3.4"
     make-fetch-happen "^13.0.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
# Why

Refs https://linear.app/expo/issue/ENG-10901/[reader-facing]-v2-add-a-search-ui-that-searches-blog-content-and-docs

# How 

This PR adds the globally available Expo Blog posts section the the Search UI component. 

Since we are using the CDN those request should not have meaningful impact on our limits/plan.

 # Preview

![Screenshot 2024-09-04 at 14 29 15](https://github.com/user-attachments/assets/ab861b13-0c05-4f0a-b22a-1dbd48ea6390)

