### PR TITLE
[styleguide] Button: add `tertiary-destructive` theme, add `2xs` size

### DIFF
--- a/packages/example-web/components/ButtonsRow.tsx
+++ b/packages/example-web/components/ButtonsRow.tsx
@@ -3,27 +3,34 @@ import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
 
 import { DemoTile } from '@/components/DemoTile';
 
-export function ButtonsRow({ theme, disabled = false }: ButtonProps) {
+type Props = ButtonProps & {
+  iconOnly?: boolean;
+};
+
+export function ButtonsRow({ theme, disabled = false, iconOnly = false }: Props) {
   return (
-    <DemoTile title={`${theme}${disabled ? ' (disabled)' : ''}`} tag="div">
-      <div className="flex flex-wrap gap-6">
+    <DemoTile title={`${theme}${disabled ? ' (disabled)' : ''}${iconOnly ? ' (icon only)' : ''}`} tag="div">
+      <div className="flex flex-wrap gap-6 items-center">
+        <Button theme={theme} size="2xs" disabled={disabled} leftSlot={<PaletteIcon />}>
+          {iconOnly ? null : 'Button 2XS'}
+        </Button>
         <Button theme={theme} size="xs" disabled={disabled} leftSlot={<PaletteIcon />}>
-          Button XS
+          {iconOnly ? null : 'Button XS'}
         </Button>
         <Button theme={theme} size="sm" disabled={disabled} leftSlot={<PaletteIcon />}>
-          Button SM
+          {iconOnly ? null : 'Button SM'}
         </Button>
         <Button theme={theme} size="md" disabled={disabled} leftSlot={<PaletteIcon />}>
-          Button MD
+          {iconOnly ? null : 'Button MD'}
         </Button>
         <Button theme={theme} size="lg" disabled={disabled} leftSlot={<PaletteIcon />}>
-          Button LG
+          {iconOnly ? null : 'Button LG'}
         </Button>
         <Button theme={theme} size="xl" disabled={disabled} leftSlot={<PaletteIcon />}>
-          Button XL
+          {iconOnly ? null : 'Button XL'}
         </Button>
         <Button theme={theme} size="2xl" disabled={disabled} leftSlot={<PaletteIcon />}>
-          Button 2XL
+          {iconOnly ? null : 'Button 2XL'}
         </Button>
       </div>
     </DemoTile>

--- a/packages/example-web/pages/ui/components.tsx
+++ b/packages/example-web/pages/ui/components.tsx
@@ -20,6 +20,7 @@ const THEMES = [
   'quaternary',
   'primary-destructive',
   'secondary-destructive',
+  'tertiary-destructive',
 ] as ButtonTheme[];
 
 export default function ComponentsPage() {
@@ -61,6 +62,12 @@ export default function ComponentsPage() {
           <ButtonsRow theme={buttonTheme} disabled />
         </Fragment>
       ))}
+      <H3 id="buttons">Icon Buttons</H3>
+      {THEMES.map((buttonTheme) => (
+        <Fragment key={`buttons-${buttonTheme}`}>
+          <ButtonsRow theme={buttonTheme} iconOnly />
+        </Fragment>
+      ))}
       <H3>Link Buttons</H3>
       <DemoTile title="local anchor">
         <Button href="#" leftSlot={<AlignTopArrow01Icon />}>
@@ -95,19 +102,6 @@ export default function ComponentsPage() {
         <Button skipNextLink href="/" theme="quaternary">
           Home
         </Button>
-      </DemoTile>
-      <H3>Icon Buttons</H3>
-      <DemoTile title="default size">
-        <Button href="#" theme="secondary" leftSlot={<AlignTopArrow01Icon />} />
-      </DemoTile>
-      <DemoTile title="medium">
-        <Button theme="primary-destructive" size="md" leftSlot={<Trash01Icon />} />
-      </DemoTile>
-      <DemoTile title="xs">
-        <Button theme="secondary-destructive" size="xs" leftSlot={<EyeOffIcon />} />
-      </DemoTile>
-      <DemoTile title="2xl">
-        <Button theme="quaternary" size="2xl" leftSlot={<DotsHorizontalIcon />} />
       </DemoTile>
       <H3>Customized Buttons</H3>
       <DemoTile title="icon with custom color">

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/lodash.groupby": "^4.6.9",
-    "tailwindcss": "^3.4.10",
+    "tailwindcss": "^3.4.14",
     "user-agent-data-types": "^0.4.2"
   },
   "peerDependencies": {

--- a/packages/styleguide-icons/package.json
+++ b/packages/styleguide-icons/package.json
@@ -36,14 +36,14 @@
     "url": "https://github.com/expo/styleguide/issues"
   },
   "dependencies": {
-    "tailwind-merge": "^2.5.2"
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
     "@figma-export/cli": "^4.7.0",
     "@figma-export/output-components-as-svgr": "^4.7.0",
     "@figma-export/transform-svg-with-svgo": "^4.7.0",
     "dotenv": "^16.3.1",
-    "tslib": "^2.6.2"
+    "tslib": "^2.8.0"
   },
   "peerDependencies": {
     "react": ">= 16"

--- a/packages/styleguide-icons/src/mergeClasses.ts
+++ b/packages/styleguide-icons/src/mergeClasses.ts
@@ -5,7 +5,7 @@ type AdditionalClassGroupIds = 'icon';
 export const mergeClasses = extendTailwindMerge<AdditionalClassGroupIds>({
   extend: {
     classGroups: {
-      icon: [{ icon: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
+      icon: [{ icon: ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
     },
   },
 });

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@expo/styleguide-base": "^1.0.1",
-    "tailwind-merge": "^2.5.2"
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.14",
-    "tailwindcss": "^3.4.10"
+    "@tailwindcss/typography": "^0.5.15",
+    "tailwindcss": "^3.4.14"
   },
   "peerDependencies": {
     "next": ">= 13",

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -6,14 +6,15 @@ import { titleCase } from './helpers';
 import { mergeClasses } from '../../helpers/mergeClasses';
 import { LinkBase, LinkBaseProps } from '../Link';
 
-export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type ButtonSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 export type ButtonTheme =
   | 'primary'
   | 'secondary'
   | 'tertiary'
   | 'quaternary'
   | 'primary-destructive'
-  | 'secondary-destructive';
+  | 'secondary-destructive'
+  | 'tertiary-destructive';
 
 export type ButtonProps = ButtonBaseProps &
   LinkBaseProps & {
@@ -26,6 +27,8 @@ export type ButtonProps = ButtonBaseProps &
 
 function getSizeClasses(size: ButtonSize) {
   switch (size) {
+    case '2xs':
+      return 'h-7 px-1.5 text-3xs';
     case 'xs':
       return 'h-8 px-3 text-3xs';
     case 'sm':
@@ -75,6 +78,13 @@ function getThemeClasses(theme: ButtonTheme, disabled = false) {
         !disabled && 'hocus:bg-button-tertiary-hover active:scale-98',
         disabled && 'bg-button-tertiary-disabled border-button-tertiary-disabled text-button-tertiary-disabled'
       );
+    case 'tertiary-destructive':
+      return mergeClasses(
+        'border-button-tertiary-destructive bg-button-tertiary-destructive text-button-tertiary-destructive shadow-none',
+        !disabled && 'hocus:bg-button-tertiary-destructive-hover active:scale-98',
+        disabled &&
+          'bg-button-tertiary-destructive-disabled border-button-tertiary-destructive-disabled text-button-tertiary-destructive-disabled'
+      );
     case 'quaternary':
       return mergeClasses(
         'border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none',
@@ -86,6 +96,8 @@ function getThemeClasses(theme: ButtonTheme, disabled = false) {
 
 function getIconSizeClasses(size: ButtonSize) {
   switch (size) {
+    case '2xs':
+      return 'icon-2xs';
     case 'xs':
       return 'icon-xs';
     case 'sm':
@@ -113,6 +125,8 @@ function getThemedIconClasses(theme: ButtonTheme) {
       return 'text-button-secondary-destructive-icon';
     case 'tertiary':
       return 'text-button-tertiary-icon';
+    case 'tertiary-destructive':
+      return 'text-button-tertiary-destructive-icon';
     case 'quaternary':
       return 'text-button-quaternary-icon';
   }
@@ -120,6 +134,8 @@ function getThemedIconClasses(theme: ButtonTheme) {
 
 function getButtonIconClasses(size: ButtonSize) {
   switch (size) {
+    case '2xs':
+      return 'px-0 w-7 justify-center items-center';
     case 'xs':
       return 'px-0 w-8 justify-center items-center';
     case 'sm':
@@ -175,7 +191,9 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
     const isSingleIconButton = (leftSlot || rightSlot) && !children;
 
     const twClasses = mergeClasses(
-      `inline-flex border border-solid rounded-md font-medium gap-2 items-center whitespace-nowrap transition`,
+      `inline-flex border border-solid rounded-md font-medium items-center whitespace-nowrap transition gap-2`,
+      size === 'xs' && 'gap-1.5',
+      size === '2xs' && 'gap-1',
       getSizeClasses(size),
       getThemeClasses(theme, disabled),
       isSingleIconButton && getButtonIconClasses(size),

--- a/packages/styleguide/src/helpers/mergeClasses.ts
+++ b/packages/styleguide/src/helpers/mergeClasses.ts
@@ -5,7 +5,7 @@ type AdditionalClassGroupIds = 'icon';
 export const mergeClasses = extendTailwindMerge<AdditionalClassGroupIds>({
   extend: {
     classGroups: {
-      icon: [{ icon: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
+      icon: [{ icon: ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
     },
   },
 });

--- a/packages/styleguide/src/styles/expo-theme.css
+++ b/packages/styleguide/src/styles/expo-theme.css
@@ -130,6 +130,15 @@
   --expo-theme-button-secondary-destructive-disabled-border: var(--red5);
   --expo-theme-button-secondary-destructive-disabled-text: var(--red8);
 
+  --expo-theme-button-tertiary-destructive-background: transparent;
+  --expo-theme-button-tertiary-destructive-border: transparent;
+  --expo-theme-button-tertiary-destructive-hover: var(--red4);
+  --expo-theme-button-tertiary-destructive-icon: var(--red9);
+  --expo-theme-button-tertiary-destructive-text: var(--red10);
+  --expo-theme-button-tertiary-destructive-disabled-background: transparent;
+  --expo-theme-button-tertiary-destructive-disabled-border: transparent;
+  --expo-theme-button-tertiary-destructive-disabled-text: var(--red8);
+
   /* Light shadows */
   --expo-theme-shadows-none: 0 0 transparent;
   --expo-theme-shadows-xs: 0 1px 3px rgba(0, 0, 0, 0.025),
@@ -243,6 +252,15 @@
   --expo-theme-button-secondary-destructive-disabled-background: var(--red2);
   --expo-theme-button-secondary-destructive-disabled-border: var(--red6);
   --expo-theme-button-secondary-destructive-disabled-text: var(--red10);
+
+  --expo-theme-button-tertiary-destructive-background: transparent;
+  --expo-theme-button-tertiary-destructive-border: transparent;
+  --expo-theme-button-tertiary-destructive-hover: var(--red3);
+  --expo-theme-button-tertiary-destructive-icon: var(--red10);
+  --expo-theme-button-tertiary-destructive-text: var(--red11);
+  --expo-theme-button-tertiary-destructive-disabled-background: transparent;
+  --expo-theme-button-tertiary-destructive-disabled-border: transparent;
+  --expo-theme-button-tertiary-destructive-disabled-text: var(--red9);
 
   /* Dark shadows */
   --expo-theme-shadows-none: 0 0 transparent;

--- a/packages/styleguide/src/styles/themes.ts
+++ b/packages/styleguide/src/styles/themes.ts
@@ -101,6 +101,18 @@ export const theme = {
         border: 'var(--expo-theme-button-tertiary-disabled-border)',
         text: 'var(--expo-theme-button-tertiary-disabled-text)',
       },
+      destructive: {
+        background: 'var(--expo-theme-button-tertiary-destructive-background)',
+        border: 'var(--expo-theme-button-tertiary-destructive-border)',
+        hover: 'var(--expo-theme-button-tertiary-destructive-hover)',
+        icon: 'var(--expo-theme-button-tertiary-destructive-icon)',
+        text: 'var(--expo-theme-button-tertiary-destructive-text)',
+        disabled: {
+          background: 'var(--expo-theme-button-tertiary-destructive-disabled-background)',
+          border: 'var(--expo-theme-button-tertiary-destructive-disabled-border)',
+          text: 'var(--expo-theme-button-tertiary-destructive-disabled-text)',
+        },
+      },
     },
     quaternary: {
       background: 'var(--expo-theme-button-quaternary-background)',

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -147,6 +147,9 @@ const expoTailwindConfig = {
       'button-tertiary': 'var(--expo-theme-button-tertiary-background)',
       'button-tertiary-hover': 'var(--expo-theme-button-tertiary-hover)',
       'button-tertiary-disabled': 'var(--expo-theme-button-tertiary-disabled-background)',
+      'button-tertiary-destructive': 'var(--expo-theme-button-tertiary-destructive-background)',
+      'button-tertiary-destructive-hover': 'var(--expo-theme-button-tertiary-destructive-hover)',
+      'button-tertiary-destructive-disabled': 'var(--expo-theme-button-tertiary-destructive-disabled-background)',
 
       'button-quaternary': 'var(--expo-theme-button-quaternary-background)',
       'button-quaternary-hover': 'var(--expo-theme-button-quaternary-hover)',
@@ -175,6 +178,8 @@ const expoTailwindConfig = {
 
       'button-tertiary': 'var(--expo-theme-button-tertiary-border)',
       'button-tertiary-disabled': 'var(--expo-theme-button-tertiary-disabled-border)',
+      'button-tertiary-destructive': 'var(--expo-theme-button-tertiary-destructive-border)',
+      'button-tertiary-destructive-disabled': 'var(--expo-theme-button-tertiary-destructive-disabled-border)',
 
       'button-quaternary': 'var(--expo-theme-button-quaternary-border)',
       'button-quaternary-disabled': 'var(--expo-theme-button-quaternary-disabled-border)',
@@ -220,6 +225,9 @@ const expoTailwindConfig = {
       'button-tertiary': 'var(--expo-theme-button-tertiary-text)',
       'button-tertiary-icon': 'var(--expo-theme-button-tertiary-icon)',
       'button-tertiary-disabled': 'var(--expo-theme-button-tertiary-disabled-text)',
+      'button-tertiary-destructive': 'var(--expo-theme-button-tertiary-destructive-text)',
+      'button-tertiary-destructive-icon': 'var(--expo-theme-button-tertiary-destructive-icon)',
+      'button-tertiary-destructive-disabled': 'var(--expo-theme-button-tertiary-destructive-disabled-text)',
 
       'button-quaternary': 'var(--expo-theme-button-quaternary-text)',
       'button-quaternary-icon': 'var(--expo-theme-button-quaternary-icon)',

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,11 +267,11 @@
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
 "@expo/styleguide-icons@latest":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-icons/-/styleguide-icons-2.0.0.tgz#0086e4f92637ddc0dab189c12546c9f442e8327e"
-  integrity sha512-YvFCdL5rZvSx/gw0O0EnE0rV7mSqjMtkYQatSJgleFXCzmSvPnTfKS1cgZ8BPMIGLFwzHMX+ow3fmO/mHFOq/g==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-icons/-/styleguide-icons-2.0.2.tgz#81345c4b854a5be260690dbf01d3e867a56ff950"
+  integrity sha512-IPfbX8xiSn3Y5L8NJFnkJEwrynmPMjcwCLKaM5GyaK79Ln2+lSprGnHF2e6i0s8EKrY0wx3lGRkeCQABC+iShQ==
   dependencies:
-    tailwind-merge "^2.3.0"
+    tailwind-merge "^2.5.2"
 
 "@expo/styleguide-search-ui@latest":
   version "2.0.1"
@@ -284,12 +284,12 @@
     lodash.groupby "^4.6.0"
 
 "@expo/styleguide@latest":
-  version "8.2.5"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.2.5.tgz#970ea5d8402fbbd42444b74ce2f87849731d95d9"
-  integrity sha512-z2/7bXei5Ub85yjt0/hNO9yZHuZGImmGBtCxE+1v+fBkk5rPRC8wFELRcvr8PDNJalgIgwKi8ht9U3pD1/BYmg==
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.2.6.tgz#bab9f9793813ec6f72f8be223c6a35981136bcea"
+  integrity sha512-3dA/b7uNCfDQ9DVeJWAFUluIB/bAtJDULBru5llOujvBvbx7xuAHDZO0L+yNdi0ipfgP2kuINUmVD1APHrNdFQ==
   dependencies:
     "@expo/styleguide-base" "^1.0.1"
-    tailwind-merge "^2.3.0"
+    tailwind-merge "^2.5.2"
 
 "@figma-export/cli@^4.7.0":
   version "4.7.0"
@@ -1460,10 +1460,10 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
-"@tailwindcss/typography@^0.5.14":
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.14.tgz#90619a3c3889eb184a53f043e38bd6e424e7b86e"
-  integrity sha512-ZvOCjUbsJBjL9CxQBn+VEnFpouzuKhxh2dH8xMIWHILL+HfOYtlAkWcyoon8LlzE53d2Yo6YO6pahKKNW3q1YQ==
+"@tailwindcss/typography@^0.5.14", "@tailwindcss/typography@^0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.15.tgz#007ab9870c86082a1c76e5b3feda9392c7c8d648"
+  integrity sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==
   dependencies:
     lodash.castarray "^4.4.0"
     lodash.isplainobject "^4.0.6"
@@ -2407,7 +2407,7 @@ cmd-shim@6.0.3, cmd-shim@^6.0.0:
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-6.0.3.tgz#c491e9656594ba17ac83c4bd931590a9d6e26033"
   integrity sha512-FMabTRlc5t5zjdenF6mS0MBeFZm0XqHqeOkcskKFb/LYCcRQ5fVgLOHVc4Lq9CqABd9zhjwPjMBCJvMCziSVtA==
 
-cmdk@^0.2.1:
+cmdk@^0.2.0, cmdk@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-0.2.1.tgz#aa8e1332bb0b8d8484e793017c82537351188d9a"
   integrity sha512-U6//9lQ6JvT47+6OF6Gi8BvkxYQ8SCRRSKIJkthIMsFsLZRG0cKvTtuTaefyIKMQb8rvvXy0wGdpTNq/jPtm+g==
@@ -7068,15 +7068,15 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
-tailwind-merge@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.5.2.tgz#000f05a703058f9f9f3829c644235f81d4c08a1f"
-  integrity sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==
+tailwind-merge@^2.5.2, tailwind-merge@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.5.4.tgz#4bf574e81fa061adeceba099ae4df56edcee78d1"
+  integrity sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==
 
-tailwindcss@^3.4.10:
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.10.tgz#70442d9aeb78758d1f911af29af8255ecdb8ffef"
-  integrity sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==
+tailwindcss@^3.4.10, tailwindcss@^3.4.14:
+  version "3.4.14"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.14.tgz#6dd23a7f54ec197b19159e91e3bb1e55e7aa73ac"
+  integrity sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     arg "^5.0.2"
@@ -7264,10 +7264,10 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.2, tslib@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.0.tgz#d124c86c3c05a40a91e6fdea4021bd31d377971b"
+  integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
 
 tuf-js@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
# Why

Looks like the build-in destruction theme variants are in some cases "too bold".

# How

Include new `tertiary-destructive` Button theme, which is based on already existing `tertiary` variant, but uses the red palette, as a base.

Additionally, I have added new `2xs` button size, since there were the cases forcing use to downsize the existing smaller Button, this also surfaced the issue with `icon-2xs` sizing, which was not present in `styleguide-icons` package class deduplicate mechanism, which caused that other icon class would overwrite that one.

Since we would need to release new packages anyway, I have also updated few of the shared dependencies.

# Test plan

The changes have been reviewed locally, by running `example-web` app.

# Preview

![Screenshot 2024-10-16 at 14 35 44](https://github.com/user-attachments/assets/9872debd-2672-493b-931d-0e0f1579ac99)

