### PR TITLE
[styleguide-icons] do not cleanup IDs, they are used for testing

### DIFF
--- a/packages/styleguide-icons/figma.config.js
+++ b/packages/styleguide-icons/figma.config.js
@@ -43,14 +43,6 @@ const outputters = [
 
 const commonSVGOConfig = [
   {
-    name: 'cleanupIDs',
-    active: true,
-    params: {
-      remove: true,
-      minify: false,
-    },
-  },
-  {
     name: 'removeHiddenElems',
     active: true,
   },


### PR DESCRIPTION
# Why

We lost easy testing ability with latest optimization efforts (since we cannot longer identify if correct icon has been rendered):
* #96

# How

Remove `cleanupIDs` optimization, `id`s might be be used directly in the code, but we relaying on them for testing purposes.

 # Test plan

Made sure locally, that after removing the optimization, icon names are present.

![Screenshot 2024-11-18 at 13 53 08](https://github.com/user-attachments/assets/2343cbb3-5e35-4ea5-bcd0-58fa6e2fdad7)

