### PR TITLE
[styleguide] force "dark" color scheme in dark theme

### DIFF
--- a/packages/styleguide/src/styles/expo-theme.css
+++ b/packages/styleguide/src/styles/expo-theme.css
@@ -156,6 +156,8 @@
 }
 
 .dark-theme {
+  color-scheme: dark;
+
   /* Backgrounds */
   --expo-theme-background-default: var(--slate-1);
   --expo-theme-background-screen: #0C0D0E;


### PR DESCRIPTION
# Why

Will fix https://github.com/expo/expo/issues/33560 after package upgrade in our apps.

# How

Force set `color-scheme: dark` in dark mode to inform browser that dark themed native components should be used, if available. Some of our apps use fully custom scrollbars, but there are cases where prefer staying with native presentation.

