### PR TITLE
Add packageManager field for Yarn version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
     "singleQuote": true,
     "bracketSameLine": true,
     "trailingComma": "es5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "bracketSameLine": true,
     "trailingComma": "es5"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Include the Yarn version in the packageManager field to specify the package manager used for the project.

corepack will now use the exact specified version and this will suppress the warning when running yarn install:

```
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```
