### PR TITLE
[styleguide] support custom `heading-*` classes in merger

### DIFF
--- a/packages/styleguide/src/helpers/mergeClasses.ts
+++ b/packages/styleguide/src/helpers/mergeClasses.ts
@@ -6,7 +6,7 @@ export const mergeClasses = extendTailwindMerge<AdditionalClassGroupIds>({
   extend: {
     classGroups: {
       icon: [{ icon: ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
-      heading: [{ heading: ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', 'xl'] }],
+      heading: [{ heading: ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl'] }],
     },
   },
 });

--- a/packages/styleguide/src/helpers/mergeClasses.ts
+++ b/packages/styleguide/src/helpers/mergeClasses.ts
@@ -1,11 +1,12 @@
 import { extendTailwindMerge } from 'tailwind-merge';
 
-type AdditionalClassGroupIds = 'icon';
+type AdditionalClassGroupIds = 'icon' | 'heading';
 
 export const mergeClasses = extendTailwindMerge<AdditionalClassGroupIds>({
   extend: {
     classGroups: {
       icon: [{ icon: ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'] }],
+      heading: [{ heading: ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', 'xl'] }],
     },
   },
 });


### PR DESCRIPTION
# Why

We have a custom `heading-*` classes declared, but they are not deduplicated correctly.
* https://github.com/expo/styleguide/blob/main/packages/styleguide/tailwind.js#L304

# How

Add the `heading` classes definition to the `mergeClasses` utils config, so issues in manually written code are spotted on the fly, and for concatenated class strings the lower priority classes are stripped.