### PR TITLE
[search-ui] improve RND item description, fix NaNs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,24 +23,37 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
+
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
+
       - name: 🧶 Yarn install
         run: yarn install --immutable
+
       - name: 🚨 Lint code
         run: yarn lint --max-warnings 0
+
       - name: ⬇️️ Pull example-web metadata
+        if: github.ref == 'refs/heads/main'
+        working-directory: packages/example-web
+        run: yarn dlx vercel pull --token ${{ secrets.VERCEL_TOKEN }} --environment=production
+
+      - name: ⬇️️ Pull example-web metadata for preview
+        if: github.ref != 'refs/heads/main'
         working-directory: packages/example-web
         run: yarn dlx vercel pull --token ${{ secrets.VERCEL_TOKEN }}
+
       - name: 📦️ Build packages
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
         run: yarn build
+
       - name: 📦️ Build example-app
         working-directory: packages/example-web
         run: yarn dlx vercel build --token ${{ secrets.VERCEL_TOKEN }}
+
       - name: 🚀 Deploy website
         uses: BetaHuhn/deploy-to-vercel-action@v1
         with:

--- a/packages/example-web/next.config.js
+++ b/packages/example-web/next.config.js
@@ -5,6 +5,9 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  devIndicators: {
+    position: 'bottom-right',
+  },
   async redirects() {
     return [
       {

--- a/packages/search-ui/src/Items/RNDirectoryItem.tsx
+++ b/packages/search-ui/src/Items/RNDirectoryItem.tsx
@@ -1,4 +1,6 @@
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { Download01Icon } from '@expo/styleguide-icons/outline/Download01Icon';
+import { Star01Icon } from '@expo/styleguide-icons/outline/Star01Icon';
 import React from 'react';
 
 import { ExternalLinkIcon } from './icons';
@@ -21,8 +23,16 @@ export const RNDirectoryItem = ({ item, onSelect, query }: Props) => {
         <GithubIcon className="text-icon-secondary" />
         <div>
           <p className="text-xs font-medium" dangerouslySetInnerHTML={{ __html: addHighlight(item.npmPkg, query) }} />
-          <p className="text-3xs text-quaternary">
-            {numberFormat.format(item.github.stats.stars)} stars · {numberFormat.format(item.npm.downloads)} downloads
+          <p className="flex items-center gap-1 text-3xs text-quaternary">
+            <Star01Icon className="icon-2xs text-icon-quaternary" />
+            {numberFormat.format(item.github.stats.stars)} stars
+            {item.npm.downloads ? (
+              <>
+                {' '}
+                · <Download01Icon className="icon-2xs text-icon-quaternary" />
+                {numberFormat.format(item.npm.downloads)} downloads
+              </>
+            ) : undefined}
           </p>
         </div>
         <ExternalLinkIcon />


### PR DESCRIPTION
# Why

Spotted that due to npm API falkiness we miss download data for several pages, which caused NaNs when attempting to reformat a number.

# How

Hande download count correctly as optional, add small icons to match the metadata visualization on the React Native directory side.

Additionally, I have updated the GHA workflow to allow fetching correct evn data, when deploying to the PROD deployment, see:
* https://github.com/expo/styleguide/actions/runs/14016971214/job/39243832065

# Preview

![Screenshot 2025-03-23 at 09 12 37](https://github.com/user-attachments/assets/042522d1-8e98-49e8-9473-a689cf0f22a8)
