### PR TITLE
[search-ui] fix meta click feature with transformed URLs

### DIFF
--- a/packages/example-web/components/search/SearchMenu.tsx
+++ b/packages/example-web/components/search/SearchMenu.tsx
@@ -31,7 +31,10 @@ export function SearchMenu() {
 
   return (
     <CommandMenu
-      config={{ docsVersion: 'latest' }}
+      config={{
+        docsVersion: 'latest',
+        docsTransformUrl: (url: string) => url,
+      }}
       open={isOpen}
       setOpen={setOpen}
       customSections={[

--- a/packages/search-ui/src/components/CommandItemBaseWithCopy.tsx
+++ b/packages/search-ui/src/components/CommandItemBaseWithCopy.tsx
@@ -48,7 +48,7 @@ export const CommandItemBaseWithCopy = ({
         }
       }}
       onSelect={() => {
-        openLink(url, isExternalLink);
+        openLink(url, isMetaClick ? true : isExternalLink);
         if (isMetaClick) {
           setMetaClick(false);
         } else {


### PR DESCRIPTION
# Why

Spotted that after upgrading `search-ui` package in docs does not allow all entries to be open via meta click properly.

# How

If meta click is detect, treat all links as external ones.

# Test plan

I have added a stub URL transform to the `search-ui` instance used in `example-web`, to cover more use-cases.