### PR TITLE
[example-native] prevent linting generated file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "out",
       "tmp",
       ".next",
+      "packages/example-native/expo-env.d.ts",
       "packages/example-web/common/icon-imports.*",
       "packages/styleguide-icons/index.*",
       "packages/styleguide-icons/mergeClasses.*"

--- a/packages/example-native/package.json
+++ b/packages/example-native/package.json
@@ -42,8 +42,5 @@
   },
   "eslintConfig": {
     "extends": "universe/native"
-  },
-  "eslintIgnore": [
-    "./expo-env.d.ts"
-  ]
+  }
 }


### PR DESCRIPTION
# Why

Spotted that ESLint still attempts to lint generated file in `example-native` app.

# How

Correct the ESLint ignores.