### PR TITLE
[styleguide] height based media breakpoint

### DIFF
--- a/packages/styleguide-icons/svgr-icon-template.js
+++ b/packages/styleguide-icons/svgr-icon-template.js
@@ -4,7 +4,7 @@ const svgrTemplate = ({ imports, interfaces, componentName, props, jsx }, { tpl,
 import { mergeClasses } from "../mergeClasses";
 
 export function ${componentName}({ className, ...props }: React.SVGProps<SVGSVGElement> & React.HTMLAttributes<SVGSVGElement>) {
-  const _className = mergeClasses("icon-md text-icon-default translate-z", className);
+  const _className = mergeClasses("icon-md text-icon-default translate-z shrink-0", className);
   return ${jsx};
 }
 

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -117,7 +117,7 @@ const appColors = {
 };
 
 const expoTailwindConfig = {
-  safelist: ['icon-md', 'text-icon-default', 'translate-z'],
+  safelist: ['icon-md', 'text-icon-default', 'translate-z', 'shrink-0'],
   darkMode: ['class', '[class*="dark-theme"]'],
   theme: {
     borderRadius: {
@@ -390,11 +390,26 @@ const expoTailwindConfig = {
       },
     },
     screens: {
-      'sm-gutters': '468px',
-      'md-gutters': '788px',
-      'lg-gutters': '1008px',
-      'xl-gutters': '1248px',
-      '2xl-gutters': '1572px',
+      // note(simek): re-generate 'max-<size>-gutters' screen scopes as 'raw' due to:
+      // https://github.com/tailwindlabs/tailwindcss/issues/13022
+      'max-2xl-gutters': {
+        raw: 'not all and (min-width: 1572px)',
+      },
+      'max-xl-gutters': {
+        raw: 'not all and (min-width: 1248px)',
+      },
+      'max-lg-gutters': {
+        raw: 'not all and (min-width: 1008px)',
+      },
+      'max-md-gutters': {
+        raw: 'not all and (min-width: 788px)',
+      },
+      'max-sm-gutters': {
+        raw: 'not all and (min-width: 468px)',
+      },
+      short: {
+        raw: '(max-height: 788px) and (min-width: 1008px)',
+      },
     },
     extend: {
       stroke: {


### PR DESCRIPTION
# Changes

[styleguide] height based media breakpoint
[styleguide-icons] apply icons shrink prevention by default

# How

Add height based media breakpoint required for navigation optimization in docs.

Add `shrink-0` class to icons by default, add it to the safelist to prevent unwanted behaviour by default.

# Tests plan

The changes have been reviewed locally by building all packages, and then running example web

# Preview

![Screenshot 2025-03-31 at 11 08 41](https://github.com/user-attachments/assets/485e67e2-da55-4c77-976e-ad2177e893e0)

