### PR TITLE
fix styleguide screens, improve example-app setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "root",
+  "name": "styleguide-root",
   "private": true,
   "scripts": {
     "build": "lerna run build --stream",
     "dev": "lerna run dev --parallel",
     "npm-publish": "lerna publish --no-private",
-    "lint": "eslint packages/*"
+    "lint": "eslint packages/example-native packages/search-ui packages/styleguide packages/styleguide-base packages/styleguide-icons packages/styleguide-native"
   },
   "workspaces": [
     "packages/*"
@@ -31,18 +31,6 @@
   "packageManager": "yarn@4.7.0",
   "eslintConfig": {
     "root": true,
-    "ignorePatterns": [
-      "node_modules",
-      "dist",
-      "out",
-      "tmp",
-      ".expo",
-      ".next",
-      "packages/example-native/expo-env.d.ts",
-      "packages/example-web/common/icon-imports.*",
-      "packages/styleguide-icons/index.*",
-      "packages/styleguide-icons/mergeClasses.*"
-    ],
     "rules": {
       "max-len": [
         "warn",
@@ -52,6 +40,17 @@
       ]
     }
   },
+  "eslintIgnore": [
+    "node_modules",
+    "dist",
+    "out",
+    "tmp",
+    ".expo",
+    ".next",
+    "packages/example-native/expo-env.d.ts",
+    "packages/styleguide-icons/index.*",
+    "packages/styleguide-icons/mergeClasses.*"
+  ],
   "prettier": {
     "printWidth": 120,
     "singleQuote": true,

--- a/packages/example-web/components/ButtonsRow.tsx
+++ b/packages/example-web/components/ButtonsRow.tsx
@@ -10,7 +10,7 @@ type Props = ButtonProps & {
 export function ButtonsRow({ theme, disabled = false, iconOnly = false }: Props) {
   return (
     <DemoTile title={`${theme}${disabled ? ' (disabled)' : ''}${iconOnly ? ' (icon only)' : ''}`} tag="div">
-      <div className="flex flex-wrap gap-6 items-center">
+      <div className="flex flex-wrap items-center gap-6">
         <Button theme={theme} size="2xs" disabled={disabled} leftSlot={<PaletteIcon />}>
           {iconOnly ? null : 'Button 2XS'}
         </Button>

--- a/packages/example-web/components/DemoTile.tsx
+++ b/packages/example-web/components/DemoTile.tsx
@@ -9,8 +9,8 @@ type DemoTileProps = PropsWithChildren<{
 
 export function DemoTile({ title, className, children = 'Build developer trust.', tag = 'p' }: DemoTileProps) {
   return (
-    <div className="flex items-center gap-2 mb-4 flex-wrap">
-      <p className="w-40 large:w-60 text-2xs text-secondary">{title}</p>
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <p className="large:w-60 w-40 text-2xs text-secondary">{title}</p>
       {createElement(tag, { className }, children)}
     </div>
   );

--- a/packages/example-web/components/Sidebar.tsx
+++ b/packages/example-web/components/Sidebar.tsx
@@ -22,13 +22,13 @@ export function Sidebar() {
   return (
     <div
       className={mergeClasses(
-        'sticky top-8 h-min z-10',
-        'max-sm-gutters:-m-8 max-sm-gutters:p-8 max-sm-gutters:top-0 max-sm-gutters:bg-default max-sm-gutters:border-b max-sm-gutters:border-b-secondary'
+        'sticky top-8 z-10 h-min',
+        'max-sm-gutters:top-0 max-sm-gutters:-m-8 max-sm-gutters:border-b max-sm-gutters:border-b-secondary max-sm-gutters:bg-default max-sm-gutters:p-8'
       )}>
       <div
         className={mergeClasses(
           'flex flex-col gap-5',
-          'max-sm-gutters:items-center max-sm-gutters:flex-row max-sm-gutters:mb-5'
+          'max-sm-gutters:mb-5 max-sm-gutters:flex-row max-sm-gutters:items-center'
         )}>
         <Link href="/" className="animate-fadeIn">
           <Image src="/icon.png" width="72" height="72" alt="Expo Styleguide Logo" className="max-sm-gutters:hidden" />
@@ -43,13 +43,13 @@ export function Sidebar() {
         <CommandMenuTrigger
           setOpen={setOpen}
           className={mergeClasses(
-            'flex w-[180px] mb-3',
+            'mb-3 flex w-[180px]',
             'max-md-gutters:w-[132px]',
             'max-sm-gutters:mb-0 max-sm-gutters:w-full'
           )}
         />
         <Button
-          className="hidden min-w-[40px] h-10 max-sm-gutters:flex"
+          className="hidden h-10 min-w-[40px] max-sm-gutters:flex"
           theme="secondary"
           leftSlot={<ThemeIcon />}
           onClick={toggleTheme}
@@ -58,11 +58,12 @@ export function Sidebar() {
       <SidebarLink href="/colors" text="Colors" />
       <SidebarLink href="/typography" text="Typography" />
       <SidebarLink href="/icons" text="Icons" />
-      <p className="heading-xl font-medium select-none">UI</p>
+      <SidebarLink href="/layouts" text="Layouts" />
+      <p className="select-none font-medium heading-xl">UI</p>
       <SidebarLink size="sm" href="/ui/components" text="Components" />
       <SidebarLink size="sm" href="/ui/search" text="Search" />
       <Button
-        className="mt-4 fixed bottom-8 max-sm-gutters:hidden"
+        className="fixed bottom-8 mt-4 max-sm-gutters:hidden"
         theme="secondary"
         leftSlot={<ThemeIcon />}
         onClick={toggleTheme}>

--- a/packages/example-web/components/SidebarLink.tsx
+++ b/packages/example-web/components/SidebarLink.tsx
@@ -14,11 +14,11 @@ export function SidebarLink({ href, text, size = 'md' }: Props) {
     <Link
       href={href}
       className={mergeClasses(
-        'font-medium flex items-center gap-2 transition-colors hover:underline',
+        'flex items-center gap-2 font-medium transition-colors hover:underline',
         pathname === href && 'text-link',
-        size === 'sm' && 'heading-base pl-2',
+        size === 'sm' && 'pl-2 heading-base',
         size === 'md' && 'heading-xl',
-        'max-sm-gutters:inline-flex max-sm-gutters:mr-2 max-sm-gutters:pl-0'
+        'max-sm-gutters:mr-2 max-sm-gutters:inline-flex max-sm-gutters:pl-0'
       )}>
       <span>{text}</span>
     </Link>

--- a/packages/example-web/components/headers.tsx
+++ b/packages/example-web/components/headers.tsx
@@ -5,7 +5,7 @@ export function H1({ children, className, ...rest }: HTMLAttributes<HTMLHeadingE
   return (
     <h1
       className={mergeClasses(
-        'heading-5xl font-black truncate',
+        'truncate font-black heading-5xl',
         'max-md-gutters:heading-4xl',
         'max-sm-gutters:heading-3xl',
         className
@@ -20,7 +20,7 @@ export function H3({ children, className, ...rest }: HTMLAttributes<HTMLHeadingE
   return (
     <h3
       className={mergeClasses(
-        'heading-3xl font-bold mt-10 mb-4 scroll-mt-5 truncate',
+        'mb-4 mt-10 scroll-mt-5 truncate font-bold heading-3xl',
         'max-md-gutters:heading-2xl',
         'max-sm-gutters:heading-xl',
         className
@@ -35,7 +35,7 @@ export function H4({ children, className, ...rest }: HTMLAttributes<HTMLHeadingE
   return (
     <h4
       className={mergeClasses(
-        'heading-lg font-semibold scroll-mt-5 mb-4 truncate',
+        'mb-4 scroll-mt-5 truncate font-semibold heading-lg',
         'max-md-gutters:heading-2xl',
         'max-sm-gutters:heading-xl',
         className

--- a/packages/example-web/components/search/QuickActionItem.tsx
+++ b/packages/example-web/components/search/QuickActionItem.tsx
@@ -28,7 +28,7 @@ export const QuickActionToggleThemeItem = ({ item, query }: Props) => {
 
   return (
     <CommandItemBase value={`quick-action-${item.label}`} onSelect={toggleTheme}>
-      <div className="inline-flex gap-3 items-center">
+      <div className="inline-flex items-center gap-3">
         <Icon className="text-icon-secondary" />
         <p className="text-xs font-medium" dangerouslySetInnerHTML={{ __html: addHighlight(item.label, query) }} />
       </div>

--- a/packages/example-web/components/search/StyleguideItem.tsx
+++ b/packages/example-web/components/search/StyleguideItem.tsx
@@ -28,7 +28,7 @@ export const StyleguideItem = ({ item, onSelect, query }: Props) => {
           linkRef?.current?.click();
           onSelect?.();
         }}>
-        <div className="inline-flex gap-3 items-center">
+        <div className="inline-flex items-center gap-3">
           <Icon className="text-icon-secondary" />
           <p className="text-xs font-medium" dangerouslySetInnerHTML={{ __html: addHighlight(item.label, query) }} />
         </div>

--- a/packages/example-web/package.json
+++ b/packages/example-web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "analyze-build": "ANALYZE=true next build",
     "update-icons": "node ./merge-icon-imports.js",
-    "clean": "rimraf .next .vercel"
+    "clean": "rimraf .next .vercel",
+    "lint": "yarn eslint ."
   },
   "dependencies": {
     "@expo/styleguide": "workspace:*",
@@ -25,8 +26,11 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "autoprefixer": "^10.4.21",
+    "eslint": "^8.57.1",
     "eslint-config-next": "^15.2.3",
+    "eslint-plugin-tailwindcss": "^3.18.0",
     "postcss": "^8.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.9",
     "rimraf": "*",
     "tailwind-merge": "^2.5.4",
     "tailwindcss": "^3.4.17"
@@ -35,18 +39,55 @@
     "cmdk": "*"
   },
   "eslintConfig": {
+    "root": true,
     "extends": [
       "universe/web",
-      "next/core-web-vitals"
+      "next/core-web-vitals",
+      "plugin:tailwindcss/recommended"
     ],
     "rules": {
       "@next/next/no-html-link-for-pages": [
+        "error"
+      ],
+      "tailwindcss/classnames-order": "off",
+      "tailwindcss/enforces-negative-arbitrary-values": "error",
+      "tailwindcss/enforces-shorthand": "error",
+      "tailwindcss/no-arbitrary-value": "off",
+      "tailwindcss/no-custom-classname": [
         "error",
-        "packages/example-web/pages"
+        {
+          "cssFiles": [],
+          "whitelist": [
+            "dark-theme"
+          ],
+          "callees": [
+            "mergeClasses"
+          ]
+        }
+      ],
+      "tailwindcss/no-unnecessary-arbitrary-value": [
+        "error",
+        {
+          "callees": [
+            "mergeClasses"
+          ]
+        }
       ]
     },
     "ignorePatterns": [
       "icon-imports.ts"
+    ]
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": true,
+    "bracketSameLine": true,
+    "trailingComma": "es5",
+    "plugins": [
+      "prettier-plugin-tailwindcss"
+    ],
+    "tailwindFunctions": [
+      "mergeClasses"
     ]
   }
 }

--- a/packages/example-web/pages/_app.tsx
+++ b/packages/example-web/pages/_app.tsx
@@ -51,7 +51,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <main
           className={mergeClasses(
             'bg-gradient-to-b from-subtle to-default',
-            'grid grid-cols-[240px_1fr] p-8 gap-8 min-h-dvh',
+            'grid min-h-dvh grid-cols-[240px_1fr] gap-8 p-8',
             'dark:from-default dark:to-screen',
             'max-md-gutters:grid-cols-[140px_1fr]',
             'max-sm-gutters:grid-cols-1 max-sm-gutters:gap-16'

--- a/packages/example-web/pages/_document.tsx
+++ b/packages/example-web/pages/_document.tsx
@@ -3,9 +3,9 @@ import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html className="a-test-class">
+    <Html>
       <Head />
-      <body className="bg-screen text-default min-h-dvh">
+      <body className="min-h-dvh bg-screen text-default">
         <BlockingSetInitialColorMode />
         <Main />
         <NextScript />

--- a/packages/example-web/pages/colors.tsx
+++ b/packages/example-web/pages/colors.tsx
@@ -11,7 +11,7 @@ export default function ColorsPage() {
       <H1>Colors</H1>
       <H3 id="semantic">Semantic</H3>
       <H4>Backgrounds</H4>
-      <div className="flex flex-wrap mb-2">
+      <div className="mb-2 flex flex-wrap">
         {[
           'bg-default',
           'bg-screen',
@@ -28,38 +28,38 @@ export default function ColorsPage() {
           <div key={index}>
             <div
               className={mergeClasses(
-                'w-16 h-16 mb-1 transition',
-                'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                'mb-1 h-16 w-16 transition',
+                'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
                 'active:scale-105',
                 className
               )}
               onClick={() => copy(className)}
             />
-            <p className="text-3xs text-secondary text-center">{className.replace('bg-', '')}</p>
+            <p className="text-center text-3xs text-secondary">{className.replace('bg-', '')}</p>
           </div>
         ))}
       </div>
       <H4 className="mt-6">Borders</H4>
-      <div className="flex flex-wrap mb-2">
+      <div className="mb-2 flex flex-wrap">
         {['border-default', 'border-secondary', 'border-success', 'border-warning', 'border-danger', 'border-info'].map(
           (className, index) => (
             <div key={index}>
               <div
                 className={mergeClasses(
-                  'w-16 h-16 mb-1 transition border-[10px]',
-                  'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                  'mb-1 h-16 w-16 border-[10px] transition',
+                  'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
                   'active:scale-105',
                   className
                 )}
                 onClick={() => copy(className)}
               />
-              <p className="text-3xs text-secondary text-center">{className.replace('border-', '')}</p>
+              <p className="text-center text-3xs text-secondary">{className.replace('border-', '')}</p>
             </div>
           )
         )}
       </div>
       <H4 className="mt-6">Text colors</H4>
-      <div className="flex flex-wrap mb-2">
+      <div className="mb-2 flex flex-wrap">
         {[
           'text-default',
           'text-secondary',
@@ -73,34 +73,34 @@ export default function ColorsPage() {
           <div key={index}>
             <div
               className={mergeClasses(
-                'inline-flex items-center justify-center heading-xl w-16 h-16 mb-1 transition font-black',
-                'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                'mb-1 inline-flex h-16 w-16 items-center justify-center font-black transition heading-xl',
+                'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
                 'active:scale-105',
                 className
               )}
               onClick={() => copy(className)}>
               T
             </div>
-            <p className="text-3xs text-secondary text-center">{className.replace('text-', '')}</p>
+            <p className="text-center text-3xs text-secondary">{className.replace('text-', '')}</p>
           </div>
         ))}
       </div>
       <H3 id="palette">Palette</H3>
-      <div className="grid gap-2 mt-8">
+      <div className="mt-8 grid gap-2">
         {['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink', 'gray'].map((color) => (
-          <div className="flex flex-wrap mb-2" key={color}>
+          <div className="mb-2 flex flex-wrap" key={color}>
             {getPaletteClasses(color).map((className, index) => (
               <div key={index}>
                 <div
                   className={mergeClasses(
-                    'w-16 h-16 mb-1 transition',
-                    'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                    'mb-1 h-16 w-16 transition',
+                    'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
                     'active:scale-105',
                     className
                   )}
                   onClick={() => copy(`palette-${color}${index + 1}`)}
                 />
-                <p className="text-3xs text-secondary text-center">
+                <p className="text-center text-3xs text-secondary">
                   {color}
                   {index + 1}
                 </p>
@@ -110,7 +110,7 @@ export default function ColorsPage() {
         ))}
       </div>
       <H3 id="project">Project background colors</H3>
-      <div className="flex flex-wrap mb-2">
+      <div className="mb-2 flex flex-wrap">
         {[
           'bg-app-cyan',
           'bg-app-light-blue',
@@ -128,14 +128,14 @@ export default function ColorsPage() {
           <div key={index}>
             <div
               className={mergeClasses(
-                'w-16 h-16 mb-1 transition',
-                'hocus:scale-110 hover:shadow-xl hocus:cursor-pointer',
+                'mb-1 h-16 w-16 transition',
+                'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
                 'active:scale-105',
                 className
               )}
               onClick={() => copy(className)}
             />
-            <p className="text-3xs text-secondary text-center">{className.replace('bg-app-', '')}</p>
+            <p className="text-center text-3xs text-secondary">{className.replace('bg-app-', '')}</p>
           </div>
         ))}
       </div>

--- a/packages/example-web/pages/icons.tsx
+++ b/packages/example-web/pages/icons.tsx
@@ -21,8 +21,8 @@ import useCopy from '@/hooks/useCopy';
 type IconNames = keyof typeof StyleguideIcons;
 
 const iconClasses = mergeClasses(
-  'flex flex-col items-center justify-center py-4 px-2 gap-1 border border-transparent rounded-md transition',
-  'hocus:border-secondary hocus:shadow-xs hover:cursor-pointer',
+  'flex flex-col items-center justify-center gap-1 rounded-md border border-transparent px-2 py-4 transition',
+  'hover:cursor-pointer hocus:border-secondary hocus:shadow-xs',
   'active:scale-98'
 );
 
@@ -65,9 +65,9 @@ export default function IconsPage() {
       <H3 id="set">Icon set</H3>
       <div className={mergeClasses('flex items-center gap-4', 'max-sm-gutters:flex-col max-sm-gutters:items-start')}>
         <div className="relative">
-          <SearchMdIcon className="icon-sm absolute top-[9px] left-2.5" />
+          <SearchMdIcon className="icon-sm absolute left-2.5 top-[9px]" />
           <input
-            className="border border-default rounded-md bg-default shadow-none py-1 px-3 pl-8 box-border outline-palette-blue8"
+            className="box-border rounded-md border border-default bg-default px-3 py-1 pl-8 shadow-none outline-palette-blue8"
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>

--- a/packages/example-web/pages/index.tsx
+++ b/packages/example-web/pages/index.tsx
@@ -8,9 +8,9 @@ export default function HomePage() {
       <H1 className="prose-strong:text-secondary">
         @expo<strong>/</strong>styleguide
       </H1>
-      <p className="text-lg mt-8">
+      <p className="mt-8 text-lg">
         A collection of packages used to share styles and icons across{' '}
-        <WordMarkLogo className="text-default w-auto h-6 inline relative -top-0.5 px-0.5" /> websites and projects.
+        <WordMarkLogo className="relative -top-0.5 inline h-6 w-auto px-0.5 text-default" /> websites and projects.
       </p>
     </>
   );

--- a/packages/example-web/pages/layouts.tsx
+++ b/packages/example-web/pages/layouts.tsx
@@ -1,0 +1,39 @@
+import { mergeClasses } from '@expo/styleguide';
+
+import { H1, H3 } from '@/components/headers';
+
+const VIEWPORT_CLASS = mergeClasses('mx-auto mt-4 min-h-40 border border-b-0 border-default bg-screen px-6 pt-4');
+const SCREEN_CLASS = mergeClasses('mx-auto mt-4 min-h-40 border border-b-0 border-secondary bg-default px-4 pt-3');
+
+export default function LayoutsPage() {
+  return (
+    <>
+      <H1>Layouts</H1>
+      <H3>screen-2xl</H3>
+      <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-2xl-gutters')}>
+        max-2xl-gutters: <span className="text-quaternary">scope or</span> max-w-screen-2xl-gutters
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-2xl')}>max-w-screen-2xl</div>
+      </div>
+      <H3>screen-xl</H3>
+      <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-xl-gutters')}>
+        max-xl-gutters: <span className="text-quaternary">scope or</span> max-w-screen-xl-gutters
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-xl')}>max-w-screen-xl</div>
+      </div>
+      <H3>screen-lg</H3>
+      <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-lg-gutters')}>
+        max-lg-gutters: <span className="text-quaternary">scope or</span> max-w-screen-lg-gutters
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-lg')}>max-w-screen-lg</div>
+      </div>
+      <H3>screen-md</H3>
+      <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-md-gutters')}>
+        max-md-gutters: <span className="text-quaternary">scope or</span> max-w-screen-md-gutters
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-md')}>max-w-screen-md</div>
+      </div>
+      <H3>screen-sm</H3>
+      <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-sm-gutters')}>
+        max-sm-gutters: <span className="text-quaternary">scope or</span> max-w-screen-sm-gutters
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-sm')}>max-w-screen-sm</div>
+      </div>
+    </>
+  );
+}

--- a/packages/example-web/pages/typography.tsx
+++ b/packages/example-web/pages/typography.tsx
@@ -7,15 +7,15 @@ export default function TypographyPage() {
       <H1>Typography</H1>
       <H3 id="headings">Headings classes</H3>
       <div className="flex flex-col gap-8">
-        <DemoTile title="heading-5xl" className="heading-5xl font-black" />
-        <DemoTile title="heading-4xl" className="heading-4xl font-extrabold" />
-        <DemoTile title="heading-3xl" className="heading-3xl font-bold" />
-        <DemoTile title="heading-2xl" className="heading-2xl font-semibold" />
-        <DemoTile title="heading-xl" className="heading-xl font-medium" />
-        <DemoTile title="heading-lg" className="heading-lg font-medium" />
-        <DemoTile title="heading-base" className="heading-base font-medium" />
-        <DemoTile title="heading-sm" className="heading-sm font-medium" />
-        <DemoTile title="heading-xs" className="heading-xs font-medium" />
+        <DemoTile title="heading-5xl" className="font-black heading-5xl" />
+        <DemoTile title="heading-4xl" className="font-extrabold heading-4xl" />
+        <DemoTile title="heading-3xl" className="font-bold heading-3xl" />
+        <DemoTile title="heading-2xl" className="font-semibold heading-2xl" />
+        <DemoTile title="heading-xl" className="font-medium heading-xl" />
+        <DemoTile title="heading-lg" className="font-medium heading-lg" />
+        <DemoTile title="heading-base" className="font-medium heading-base" />
+        <DemoTile title="heading-sm" className="font-medium heading-sm" />
+        <DemoTile title="heading-xs" className="font-medium heading-xs" />
       </div>
       <H3 id="elements">Text classes</H3>
       <div className="flex flex-col gap-8">

--- a/packages/example-web/pages/ui/components.tsx
+++ b/packages/example-web/pages/ui/components.tsx
@@ -27,25 +27,25 @@ export default function ComponentsPage() {
       <H1>UI: Components</H1>
       <H3>Inline Help</H3>
       <DemoTile title="info" tag="div">
-        <div className="rounded-lg bg-info border border-info text-info px-3 py-1.5 flex gap-2 items-center shadow-xs text-sm">
+        <div className="flex items-center gap-2 rounded-lg border border-info bg-info px-3 py-1.5 text-sm text-info shadow-xs">
           <EasMetadataIcon className="icon-sm text-icon-info" />
           Info text
         </div>
       </DemoTile>
       <DemoTile title="warning" tag="div">
-        <div className="rounded-lg bg-warning border border-warning text-warning px-3 py-1.5 flex gap-2 items-center shadow-xs text-sm">
+        <div className="flex items-center gap-2 rounded-lg border border-warning bg-warning px-3 py-1.5 text-sm text-warning shadow-xs">
           <EasMetadataIcon className="icon-sm text-icon-warning" />
           Warning text
         </div>
       </DemoTile>
       <DemoTile title="danger" tag="div">
-        <div className="rounded-lg bg-danger border border-danger text-danger px-3 py-1.5 flex gap-2 items-center shadow-xs text-sm">
+        <div className="flex items-center gap-2 rounded-lg border border-danger bg-danger px-3 py-1.5 text-sm text-danger shadow-xs">
           <EasMetadataIcon className="icon-sm text-icon-danger" />
           Danger text
         </div>
       </DemoTile>
       <DemoTile title="success" tag="div">
-        <div className="rounded-lg bg-success border border-success text-success px-3 py-1.5 flex gap-2 items-center shadow-xs text-sm">
+        <div className="flex items-center gap-2 rounded-lg border border-success bg-success px-3 py-1.5 text-sm text-success shadow-xs">
           <EasMetadataIcon className="icon-sm text-icon-success" />
           Success text
         </div>
@@ -142,13 +142,13 @@ export default function ComponentsPage() {
       </DemoTile>
       <DemoTile title="custom button">
         <Button
-          className="bg-palette-green3 border-palette-green7 text-success hocus:bg-palette-green4"
+          className="border-palette-green7 bg-palette-green3 text-success hocus:bg-palette-green4"
           rightSlot={<EasMetadataIcon className="text-success" />}>
           EAS Metadata
         </Button>
         <Button
           href="#"
-          className="ml-4 bg-palette-green3 border-palette-green7 text-success hocus:bg-palette-green4"
+          className="ml-4 border-palette-green7 bg-palette-green3 text-success hocus:bg-palette-green4"
           rightSlot={<EasMetadataIcon className="text-success" />}>
           EAS Metadata
         </Button>
@@ -156,8 +156,8 @@ export default function ComponentsPage() {
       <DemoTile title="custom slot content">
         <Button
           theme="quaternary"
-          className="hocus:bg-palette-yellow2 hocus:border-palette-yellow6"
-          leftSlot={<span className="icon-2xs bg-palette-yellow10 rounded-md" />}
+          className="hocus:border-palette-yellow6 hocus:bg-palette-yellow2"
+          leftSlot={<span className="icon-2xs rounded-md bg-palette-yellow10" />}
           testID="test-button"
           skipCapitalization>
           Check status
@@ -165,15 +165,15 @@ export default function ComponentsPage() {
         <Button
           href="#"
           theme="quaternary"
-          className="ml-4 hocus:bg-palette-yellow2 hocus:border-palette-yellow6"
-          leftSlot={<span className="icon-2xs bg-palette-yellow10 rounded-md" />}
+          className="ml-4 hocus:border-palette-yellow6 hocus:bg-palette-yellow2"
+          leftSlot={<span className="icon-2xs rounded-md bg-palette-yellow10" />}
           testID="test-link"
           skipCapitalization>
           Check status
         </Button>
       </DemoTile>
       <DemoTile title="forced dark theme">
-        <span className="dark-theme flex bg-screen p-4 rounded-lg gap-4">
+        <span className="dark-theme flex gap-4 rounded-lg bg-screen p-4">
           <Button theme="secondary" className="dark-theme">
             Dark button
           </Button>

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -390,26 +390,11 @@ const expoTailwindConfig = {
       },
     },
     screens: {
-      // note(simek): re-generate 'max-<size>-gutters' screen scopes as 'raw' due to:
-      // https://github.com/tailwindlabs/tailwindcss/issues/13022
-      'max-2xl-gutters': {
-        raw: 'not all and (min-width: 1572px)',
-      },
-      'max-xl-gutters': {
-        raw: 'not all and (min-width: 1248px)',
-      },
-      'max-lg-gutters': {
-        raw: 'not all and (min-width: 1008px)',
-      },
-      'max-md-gutters': {
-        raw: 'not all and (min-width: 788px)',
-      },
-      'max-sm-gutters': {
-        raw: 'not all and (min-width: 468px)',
-      },
-      short: {
-        raw: '(max-height: 788px) and (min-width: 1008px)',
-      },
+      'sm-gutters': '468px',
+      'md-gutters': '788px',
+      'lg-gutters': '1008px',
+      'xl-gutters': '1248px',
+      '2xl-gutters': '1572px',
     },
     extend: {
       stroke: {
@@ -447,7 +432,6 @@ const expoTailwindConfig = {
       },
       maxWidth: {
         15: '3.75rem',
-        'screen-xs': '340px',
         'screen-sm': '420px',
         'screen-md': '740px',
         'screen-lg': '960px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7814,6 +7814,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-tailwindcss@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "eslint-plugin-tailwindcss@npm:3.18.0"
+  dependencies:
+    fast-glob: "npm:^3.2.5"
+    postcss: "npm:^8.4.4"
+  peerDependencies:
+    tailwindcss: ^3.4.0
+  checksum: 10/5145aa8884e5a4c699305c9cc1546ef30904bd11b0ef2779cace23ed1676688c5956f5fb68bc70e7ac1b48b185d3239923813df2cf19c1df720caa4d0965b7a3
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^7.2.2":
   version: 7.2.2
   resolution: "eslint-scope@npm:7.2.2"
@@ -7854,7 +7866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.57.0":
+"eslint@npm:^8.57.0, eslint@npm:^8.57.1":
   version: 8.57.1
   resolution: "eslint@npm:8.57.1"
   dependencies:
@@ -8048,9 +8060,12 @@ __metadata:
     "@types/react": "npm:^18.3.12"
     "@types/react-dom": "npm:^18.3.1"
     autoprefixer: "npm:^10.4.21"
+    eslint: "npm:^8.57.1"
     eslint-config-next: "npm:^15.2.3"
+    eslint-plugin-tailwindcss: "npm:^3.18.0"
     next: "npm:^15.2.3"
     postcss: "npm:^8.5.3"
+    prettier-plugin-tailwindcss: "npm:^0.6.9"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     rimraf: "npm:*"
@@ -13416,7 +13431,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.47, postcss@npm:^8.5.3":
+"postcss@npm:^8.4.4, postcss@npm:^8.4.47, postcss@npm:^8.5.3":
   version: 8.5.3
   resolution: "postcss@npm:8.5.3"
   dependencies:
@@ -13451,6 +13466,64 @@ __metadata:
   dependencies:
     fast-diff: "npm:^1.1.2"
   checksum: 10/00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-tailwindcss@npm:^0.6.9":
+  version: 0.6.11
+  resolution: "prettier-plugin-tailwindcss@npm:0.6.11"
+  peerDependencies:
+    "@ianvs/prettier-plugin-sort-imports": "*"
+    "@prettier/plugin-pug": "*"
+    "@shopify/prettier-plugin-liquid": "*"
+    "@trivago/prettier-plugin-sort-imports": "*"
+    "@zackad/prettier-plugin-twig": "*"
+    prettier: ^3.0
+    prettier-plugin-astro: "*"
+    prettier-plugin-css-order: "*"
+    prettier-plugin-import-sort: "*"
+    prettier-plugin-jsdoc: "*"
+    prettier-plugin-marko: "*"
+    prettier-plugin-multiline-arrays: "*"
+    prettier-plugin-organize-attributes: "*"
+    prettier-plugin-organize-imports: "*"
+    prettier-plugin-sort-imports: "*"
+    prettier-plugin-style-order: "*"
+    prettier-plugin-svelte: "*"
+  peerDependenciesMeta:
+    "@ianvs/prettier-plugin-sort-imports":
+      optional: true
+    "@prettier/plugin-pug":
+      optional: true
+    "@shopify/prettier-plugin-liquid":
+      optional: true
+    "@trivago/prettier-plugin-sort-imports":
+      optional: true
+    "@zackad/prettier-plugin-twig":
+      optional: true
+    prettier-plugin-astro:
+      optional: true
+    prettier-plugin-css-order:
+      optional: true
+    prettier-plugin-import-sort:
+      optional: true
+    prettier-plugin-jsdoc:
+      optional: true
+    prettier-plugin-marko:
+      optional: true
+    prettier-plugin-multiline-arrays:
+      optional: true
+    prettier-plugin-organize-attributes:
+      optional: true
+    prettier-plugin-organize-imports:
+      optional: true
+    prettier-plugin-sort-imports:
+      optional: true
+    prettier-plugin-style-order:
+      optional: true
+    prettier-plugin-svelte:
+      optional: true
+  checksum: 10/7c87d8b9c7fc6e8bd3722da5c0bd115cfc249baba339b28b56ed270f0bcb99e0196836cd7270c8ab6bc499186f41e2bac4adff7795cd523d8f63f43424a0a36d
   languageName: node
   linkType: hard
 
@@ -14668,26 +14741,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"root@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "root@workspace:."
-  dependencies:
-    "@rollup/plugin-terser": "npm:^0.4.4"
-    "@rollup/plugin-typescript": "npm:^12.1.2"
-    "@types/react": "npm:^18.3.12"
-    eslint: "npm:^8.57.0"
-    eslint-config-universe: "npm:^14.0.0"
-    lerna: "npm:^8.2.1"
-    npm-run-all: "npm:^4.1.5"
-    prettier: "npm:^3.5.3"
-    react: "npm:^18.3.1"
-    rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.36.0"
-    rollup-plugin-copy: "npm:^3.5.0"
-    typescript: "npm:^5.6.3"
-  languageName: unknown
-  linkType: soft
-
 "run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -15724,6 +15777,26 @@ __metadata:
   checksum: 10/ba01200e8227fe1441a719c2e7da96c8aa7ef61d14211d1500e1abce12efa118479bcb6e7e12beecb9e1db76432caad2f4e01bbc0c9be21c134b088a4ca5ffe0
   languageName: node
   linkType: hard
+
+"styleguide-root@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "styleguide-root@workspace:."
+  dependencies:
+    "@rollup/plugin-terser": "npm:^0.4.4"
+    "@rollup/plugin-typescript": "npm:^12.1.2"
+    "@types/react": "npm:^18.3.12"
+    eslint: "npm:^8.57.0"
+    eslint-config-universe: "npm:^14.0.0"
+    lerna: "npm:^8.2.1"
+    npm-run-all: "npm:^4.1.5"
+    prettier: "npm:^3.5.3"
+    react: "npm:^18.3.1"
+    rimraf: "npm:^6.0.1"
+    rollup: "npm:^4.36.0"
+    rollup-plugin-copy: "npm:^3.5.0"
+    typescript: "npm:^5.6.3"
+  languageName: unknown
+  linkType: soft
 
 "styleq@npm:^0.1.3":
   version: 0.1.3


### PR DESCRIPTION
# Why

Using custom object-like (`raw`) breakpoints breaks autogeneration of some properties:
![Screenshot 2025-03-31 at 22 05 50](https://github.com/user-attachments/assets/481fe559-1511-4d93-9498-0691b03a4e27)

# How

Drop custom screen from the preset (it can be defined manually in app which need it, which should help us avoid unwanted side-effects related to auto generated by tailwind screen classes. I have also removed legacy custom `screen-xs` with definition.

Additionally, the `example-web` app includes now Layouts page explaining available screens and fully-fledged lint setup, including Tailwind part, which mimic the general config we use in apps utilizing styleguide.

# Preview

![Screenshot 2025-03-31 at 22 10 05](https://github.com/user-attachments/assets/8f85113d-3713-4cce-92b3-394b9ae7f373)
