### PR TITLE
compat height variant, example app improvements

### DIFF
--- a/packages/example-web/components/Sidebar.tsx
+++ b/packages/example-web/components/Sidebar.tsx
@@ -23,33 +23,37 @@ export function Sidebar() {
     <div
       className={mergeClasses(
         'sticky top-8 z-10 h-min',
-        'max-sm-gutters:top-0 max-sm-gutters:-m-8 max-sm-gutters:border-b max-sm-gutters:border-b-secondary max-sm-gutters:bg-default max-sm-gutters:p-8'
+        'max-md-gutters:top-0 max-md-gutters:-m-8',
+        'max-md-gutters:border-b max-md-gutters:border-b-secondary max-md-gutters:bg-default',
+        'max-md-gutters:p-6 max-md-gutters:pb-5'
       )}>
       <div
         className={mergeClasses(
           'flex flex-col gap-5',
-          'max-sm-gutters:mb-5 max-sm-gutters:flex-row max-sm-gutters:items-center'
+          'max-md-gutters:mb-5 max-md-gutters:flex-row max-md-gutters:items-center'
         )}>
         <Link href="/" className="animate-fadeIn">
-          <Image src="/icon.png" width="72" height="72" alt="Expo Styleguide Logo" className="max-sm-gutters:hidden" />
+          <Image
+            src="/icon.png"
+            width="72"
+            height="72"
+            alt="Expo Styleguide Logo"
+            className="compact-height:hidden max-md-gutters:hidden"
+          />
           <Image
             src="/icon.png"
             width="40"
             height="40"
             alt="Expo Styleguide Logo"
-            className="hidden min-w-[40px] max-sm-gutters:block"
+            className="compact-height:block hidden min-w-[40px] max-md-gutters:block"
           />
         </Link>
         <CommandMenuTrigger
           setOpen={setOpen}
-          className={mergeClasses(
-            'mb-3 flex w-[180px]',
-            'max-md-gutters:w-[132px]',
-            'max-sm-gutters:mb-0 max-sm-gutters:w-full'
-          )}
+          className={mergeClasses('mb-3 flex w-[180px]', 'max-md-gutters:mb-0 max-md-gutters:w-full')}
         />
         <Button
-          className="hidden h-10 min-w-[40px] max-sm-gutters:flex"
+          className="hidden h-10 min-w-[40px] max-md-gutters:flex"
           theme="secondary"
           leftSlot={<ThemeIcon />}
           onClick={toggleTheme}
@@ -59,11 +63,13 @@ export function Sidebar() {
       <SidebarLink href="/typography" text="Typography" />
       <SidebarLink href="/icons" text="Icons" />
       <SidebarLink href="/layouts" text="Layouts" />
-      <p className="select-none font-medium heading-xl">UI</p>
-      <SidebarLink size="sm" href="/ui/components" text="Components" />
-      <SidebarLink size="sm" href="/ui/search" text="Search" />
+      <div className="gap-x-3 max-md-gutters:flex max-md-gutters:flex-row">
+        <p className="select-none font-medium heading-xl">UI</p>
+        <SidebarLink size="sm" href="/ui/components" text="Components" />
+        <SidebarLink size="sm" href="/ui/search" text="Search" />
+      </div>
       <Button
-        className="fixed bottom-8 mt-4 max-sm-gutters:hidden"
+        className="fixed bottom-8 mt-4 max-md-gutters:hidden"
         theme="secondary"
         leftSlot={<ThemeIcon />}
         onClick={toggleTheme}>

--- a/packages/example-web/components/SidebarLink.tsx
+++ b/packages/example-web/components/SidebarLink.tsx
@@ -18,7 +18,7 @@ export function SidebarLink({ href, text, size = 'md' }: Props) {
         pathname === href && 'text-link',
         size === 'sm' && 'pl-2 heading-base',
         size === 'md' && 'heading-xl',
-        'max-sm-gutters:mr-2 max-sm-gutters:inline-flex max-sm-gutters:pl-0'
+        'max-md-gutters:mr-2 max-md-gutters:inline-flex max-md-gutters:pl-0'
       )}>
       <span>{text}</span>
     </Link>

--- a/packages/example-web/components/headers.tsx
+++ b/packages/example-web/components/headers.tsx
@@ -20,9 +20,9 @@ export function H3({ children, className, ...rest }: HTMLAttributes<HTMLHeadingE
   return (
     <h3
       className={mergeClasses(
-        'mb-4 mt-10 scroll-mt-5 truncate font-bold heading-3xl',
-        'max-md-gutters:heading-2xl',
-        'max-sm-gutters:heading-xl',
+        'mb-4 mt-8 scroll-mt-5 truncate font-semibold heading-2xl',
+        'max-md-gutters:heading-xl',
+        'max-sm-gutters:heading-lg',
         className
       )}
       {...rest}>
@@ -36,8 +36,8 @@ export function H4({ children, className, ...rest }: HTMLAttributes<HTMLHeadingE
     <h4
       className={mergeClasses(
         'mb-4 scroll-mt-5 truncate font-semibold heading-lg',
-        'max-md-gutters:heading-2xl',
-        'max-sm-gutters:heading-xl',
+        'max-md-gutters:heading-base',
+        'max-sm-gutters:heading-sm',
         className
       )}
       {...rest}>

--- a/packages/example-web/pages/_app.tsx
+++ b/packages/example-web/pages/_app.tsx
@@ -51,10 +51,9 @@ export default function App({ Component, pageProps }: AppProps) {
         <main
           className={mergeClasses(
             'bg-gradient-to-b from-subtle to-default',
-            'grid min-h-dvh grid-cols-[240px_1fr] gap-8 p-8',
+            'grid min-h-dvh grid-cols-[200px_1fr] gap-8 p-8',
             'dark:from-default dark:to-screen',
-            'max-md-gutters:grid-cols-[140px_1fr]',
-            'max-sm-gutters:grid-cols-1 max-sm-gutters:gap-16'
+            'max-md-gutters:grid-cols-1 max-md-gutters:gap-16'
           )}>
           <Sidebar />
           <div>

--- a/packages/example-web/pages/layouts.tsx
+++ b/packages/example-web/pages/layouts.tsx
@@ -2,8 +2,10 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { H1, H3 } from '@/components/headers';
 
-const VIEWPORT_CLASS = mergeClasses('mx-auto mt-4 min-h-40 border border-b-0 border-default bg-screen px-6 pt-4');
-const SCREEN_CLASS = mergeClasses('mx-auto mt-4 min-h-40 border border-b-0 border-secondary bg-default px-4 pt-3');
+const VIEWPORT_CLASS = mergeClasses(
+  'mx-auto mt-4 border border-default bg-screen px-6 pt-4 pb-5 rounded-lg shadow-xs'
+);
+const SCREEN_CLASS = mergeClasses('mx-auto mt-4 min-h-28 border border-secondary bg-default px-4 pt-3 rounded-md');
 
 export default function LayoutsPage() {
   return (
@@ -11,29 +13,64 @@ export default function LayoutsPage() {
       <H1>Layouts</H1>
       <H3>screen-2xl</H3>
       <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-2xl-gutters')}>
-        max-2xl-gutters: <span className="text-quaternary">scope or</span> max-w-screen-2xl-gutters
-        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-2xl')}>max-w-screen-2xl</div>
+        max-2xl-gutters: <span className="text-quaternary">scope or</span>{' '}
+        <WidthExplanation screen="screen-2xl-gutters" />
+        <span className="text-2xs text-tertiary">1572px</span>
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-2xl')}>
+          <WidthExplanation screen="screen-2xl" />
+          <span className="text-2xs text-tertiary">1524px</span>
+        </div>
       </div>
       <H3>screen-xl</H3>
       <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-xl-gutters')}>
-        max-xl-gutters: <span className="text-quaternary">scope or</span> max-w-screen-xl-gutters
-        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-xl')}>max-w-screen-xl</div>
+        max-xl-gutters: <span className="text-quaternary">scope or</span>{' '}
+        <WidthExplanation screen="screen-xl-gutters" />
+        <span className="text-2xs text-tertiary">1248px</span>
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-xl')}>
+          <WidthExplanation screen="screen-xl" />
+          <span className="text-2xs text-tertiary">1200px</span>
+        </div>
       </div>
       <H3>screen-lg</H3>
       <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-lg-gutters')}>
-        max-lg-gutters: <span className="text-quaternary">scope or</span> max-w-screen-lg-gutters
-        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-lg')}>max-w-screen-lg</div>
+        max-lg-gutters: <span className="text-quaternary">scope or</span>{' '}
+        <WidthExplanation screen="screen-lg-gutters" />
+        <span className="text-2xs text-tertiary">1008px</span>
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-lg')}>
+          <WidthExplanation screen="screen-lg" />
+          <span className="text-2xs text-tertiary">960px</span>
+        </div>
       </div>
       <H3>screen-md</H3>
       <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-md-gutters')}>
-        max-md-gutters: <span className="text-quaternary">scope or</span> max-w-screen-md-gutters
-        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-md')}>max-w-screen-md</div>
+        max-md-gutters: <span className="text-quaternary">scope or</span>{' '}
+        <WidthExplanation screen="screen-md-gutters" />
+        <span className="text-2xs text-tertiary">788px</span>
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-md')}>
+          <WidthExplanation screen="screen-md" />
+          <span className="text-2xs text-tertiary">740px</span>
+        </div>
       </div>
       <H3>screen-sm</H3>
       <div className={mergeClasses(VIEWPORT_CLASS, 'mx-0 border-b', 'max-w-screen-sm-gutters')}>
-        max-sm-gutters: <span className="text-quaternary">scope or</span> max-w-screen-sm-gutters
-        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-sm')}>max-w-screen-sm</div>
+        max-sm-gutters: <span className="text-quaternary">scope or</span>{' '}
+        <WidthExplanation screen="screen-sm-gutters" />
+        <span className="text-2xs text-tertiary">468px</span>
+        <div className={mergeClasses(SCREEN_CLASS, 'max-w-screen-sm')}>
+          <WidthExplanation screen="screen-sm" />
+          <span className="text-2xs text-tertiary">420px</span>
+        </div>
       </div>
+    </>
+  );
+}
+
+function WidthExplanation({ screen }: { screen: string }) {
+  return (
+    <>
+      <span className="text-quaternary">(</span>w<span className="text-quaternary">/</span>min-w
+      <span className="text-quaternary">/</span>max-w<span className="text-quaternary">)</span>-{screen}
+      <br />
     </>
   );
 }

--- a/packages/example-web/pages/typography.tsx
+++ b/packages/example-web/pages/typography.tsx
@@ -6,7 +6,7 @@ export default function TypographyPage() {
     <>
       <H1>Typography</H1>
       <H3 id="headings">Headings classes</H3>
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
         <DemoTile title="heading-5xl" className="font-black heading-5xl" />
         <DemoTile title="heading-4xl" className="font-extrabold heading-4xl" />
         <DemoTile title="heading-3xl" className="font-bold heading-3xl" />
@@ -18,7 +18,7 @@ export default function TypographyPage() {
         <DemoTile title="heading-xs" className="font-medium heading-xs" />
       </div>
       <H3 id="elements">Text classes</H3>
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
         <DemoTile title="text-3xl" className="text-3xl" />
         <DemoTile title="text-2xl" className="text-2xl" />
         <DemoTile title="text-xl" className="text-xl" />
@@ -29,8 +29,10 @@ export default function TypographyPage() {
         <DemoTile title="text-2xs" className="text-2xs" />
         <DemoTile title="text-3xs" className="text-3xs" />
       </div>
-      <H3 id="elements">Elements (legacy)</H3>
-      <div className="flex flex-col gap-8">
+      <H3 id="elements" className="opacity-80">
+        <span className="line-through">Elements</span> (legacy)
+      </H3>
+      <div className="flex flex-col gap-4 opacity-60">
         <DemoTile title="Headline" className="text-base font-medium" />
         <DemoTile title="Paragraph" className="text-base font-normal" />
         <DemoTile title="Label" className="text-sm font-medium" />

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -475,20 +475,12 @@ const expoTailwindConfig = {
       },
       keyframes: {
         fadeIn: {
-          '0%': {
-            opacity: 0,
-          },
-          '100%': {
-            opacity: 1,
-          },
+          '0%': { opacity: 0 },
+          '100%': { opacity: 1 },
         },
         fadeOut: {
-          '0%': {
-            opacity: 1,
-          },
-          '100%': {
-            opacity: 0,
-          },
+          '0%': { opacity: 1 },
+          '100%': { opacity: 0 },
         },
         slideDownAndFade: {
           '0%': {
@@ -559,7 +551,10 @@ const expoTailwindConfig = {
   plugins: [
     plugin(({ addComponents, addVariant, matchUtilities, theme }) => {
       addVariant('hocus', ['&:hover', '&:focus-visible']);
+      addVariant('compact-height', `@media (max-height: 788px) and (min-width: 1008px)`);
+
       matchUtilities({ heading: (value) => value }, { values: theme('heading') });
+
       addComponents({
         '.icon-2xs': {
           height: theme('height.3'),
@@ -590,19 +585,21 @@ const expoTailwindConfig = {
           height: theme('height.10'),
           width: theme('width.10'),
         },
+
         '.translate-z': {
           transform: 'translateZ(0)',
         },
+
         '.break-words': { 'word-break': 'break-word' },
         '.wrap-anywhere': { 'overflow-wrap': 'anywhere' },
+
         '.pause-animation': { 'animation-play-state': 'paused' },
         '.transform-box': { 'transform-box': 'fill-box' },
-        '.overflow-wrap-anywhere': {
-          'overflow-wrap': 'anywhere',
-        },
+
         '.backface-hidden': {
           'backface-visibility': 'hidden',
         },
+
         '.variant-numeric-normal': {
           'font-variant-numeric': 'normal',
         },
@@ -612,6 +609,7 @@ const expoTailwindConfig = {
         '.variant-numeric-tabular': {
           'font-variant-numeric': 'tabular-nums',
         },
+
         '.asset-shadow': {
           filter: 'drop-shadow(0 3px 10px rgba(0, 0, 0, 0.12)) drop-shadow(0 2px 6px rgba(0, 0, 0, 0.07))',
         },


### PR DESCRIPTION
# Why

Use plugins API to define required height-based media query.

# How

Add test case for the new breakpoint on the example app logo, additionally, I have ugraded and make more informative the Layout page.

# Preview
 
![Screenshot 2025-04-01 at 11 13 23](https://github.com/user-attachments/assets/6d6f8eaa-6e1b-409c-bf2e-d2f218db1212)

![Screenshot 2025-04-01 at 11 13 47](https://github.com/user-attachments/assets/caf74f5e-1879-452c-a67e-36245e6ba981)
