### PR TITLE
add LogRocket and Sentry icons

### DIFF
--- a/packages/example-web/common/icon-imports.ts
+++ b/packages/example-web/common/icon-imports.ts
@@ -28,6 +28,7 @@ export { HeadsetIcon } from '@expo/styleguide-icons/custom/HeadsetIcon';
 export { InspectElementIcon } from '@expo/styleguide-icons/custom/InspectElementIcon';
 export { InstagramIcon } from '@expo/styleguide-icons/custom/InstagramIcon';
 export { LinkedinIcon } from '@expo/styleguide-icons/custom/LinkedinIcon';
+export { LogrocketIcon } from '@expo/styleguide-icons/custom/LogrocketIcon';
 export { LogsIcon } from '@expo/styleguide-icons/custom/LogsIcon';
 export { MastodonIcon } from '@expo/styleguide-icons/custom/MastodonIcon';
 export { NpmIcon } from '@expo/styleguide-icons/custom/NpmIcon';
@@ -48,6 +49,7 @@ export { RequestUnhandledIcon } from '@expo/styleguide-icons/custom/RequestUnhan
 export { RolloutIcon } from '@expo/styleguide-icons/custom/RolloutIcon';
 export { RunIcon } from '@expo/styleguide-icons/custom/RunIcon';
 export { RuntimeVersionIcon } from '@expo/styleguide-icons/custom/RuntimeVersionIcon';
+export { SentryIcon } from '@expo/styleguide-icons/custom/SentryIcon';
 export { SlashShortcutIcon } from '@expo/styleguide-icons/custom/SlashShortcutIcon';
 export { Smartphone01Icon } from '@expo/styleguide-icons/custom/Smartphone01Icon';
 export { Smartphone02Icon } from '@expo/styleguide-icons/custom/Smartphone02Icon';


### PR DESCRIPTION
Add LogRocket and Sentry icons, refetch set to verify icons are present, regenerate website imports file.

## Preview

![Screenshot 2025-05-08 at 10 41 04](https://github.com/user-attachments/assets/5349adb0-1288-4979-b827-bed285177c58)
