### PR TITLE
[styleguide] Export `activeTheme` from `ThemeProvider`

### DIFF
--- a/packages/styleguide/src/components/Theme/ThemeProvider.tsx
+++ b/packages/styleguide/src/components/Theme/ThemeProvider.tsx
@@ -15,7 +15,7 @@ const ThemeContext = createContext<{
   setAutoMode: () => void;
   themeName: Themes;
 }>({
-  activeTheme: Themes.LIGHT,
+  activeTheme: undefined,
   setDarkMode: () => {},
   setLightMode: () => {},
   setAutoMode: () => {},

--- a/packages/styleguide/src/components/Theme/ThemeProvider.tsx
+++ b/packages/styleguide/src/components/Theme/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useState, useContext, ReactNode } from 'react';
+import React, { createContext, useEffect, useState, useContext, ReactNode, useMemo } from 'react';
 
 import { getInitialColorMode, isLocalStorageAvailable } from './BlockingSetInitialColorMode';
 
@@ -8,7 +8,14 @@ export enum Themes {
   LIGHT = 'light',
 }
 
-const ThemeContext = createContext({
+const ThemeContext = createContext<{
+  activeTheme: 'light' | 'dark';
+  setDarkMode: () => void;
+  setLightMode: () => void;
+  setAutoMode: () => void;
+  themeName: Themes;
+}>({
+  activeTheme: Themes.LIGHT,
   setDarkMode: () => {},
   setLightMode: () => {},
   setAutoMode: () => {},
@@ -58,6 +65,14 @@ export function ThemeProvider(props: ThemeProviderProps) {
       }
     };
   }, []);
+
+  const activeTheme = useMemo(() => {
+    if (themeName !== Themes.AUTO) {
+      return themeName;
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? Themes.DARK : Themes.LIGHT;
+  }, [themeName]);
 
   function setDocumentTheme(themeName: Themes) {
     if (disabled) return;
@@ -114,6 +129,7 @@ export function ThemeProvider(props: ThemeProviderProps) {
   return (
     <ThemeContext.Provider
       value={{
+        activeTheme,
         setDarkMode,
         setLightMode,
         setAutoMode,

--- a/packages/styleguide/src/components/Theme/ThemeProvider.tsx
+++ b/packages/styleguide/src/components/Theme/ThemeProvider.tsx
@@ -64,6 +64,14 @@ export function ThemeProvider(props: ThemeProviderProps) {
     };
   }, []);
 
+  useEffect(
+    function onThemeNameChange() {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setActiveTheme(themeName === Themes.AUTO ? (prefersDark ? Themes.DARK : Themes.LIGHT) : themeName);
+    },
+    [themeName]
+  );
+
   function setDocumentTheme(themeName: Themes) {
     if (disabled) return;
 
@@ -96,7 +104,6 @@ export function ThemeProvider(props: ThemeProviderProps) {
     }
     setDocumentTheme(Themes.DARK);
     setThemeName(Themes.DARK);
-    setActiveTheme(Themes.DARK);
   }
 
   function setLightMode() {
@@ -105,7 +112,6 @@ export function ThemeProvider(props: ThemeProviderProps) {
     }
     setDocumentTheme(Themes.LIGHT);
     setThemeName(Themes.LIGHT);
-    setActiveTheme(Themes.LIGHT);
   }
 
   function setAutoMode() {
@@ -116,7 +122,6 @@ export function ThemeProvider(props: ThemeProviderProps) {
     const themeName = getInitialColorMode() as Themes.LIGHT | Themes.DARK;
     setDocumentTheme(themeName);
     setThemeName(Themes.AUTO);
-    setActiveTheme(themeName);
   }
 
   return (

--- a/packages/styleguide/src/components/Theme/ThemeProvider.tsx
+++ b/packages/styleguide/src/components/Theme/ThemeProvider.tsx
@@ -9,7 +9,7 @@ export enum Themes {
 }
 
 const ThemeContext = createContext<{
-  activeTheme: 'light' | 'dark';
+  activeTheme: Themes.LIGHT | Themes.DARK | undefined;
   setDarkMode: () => void;
   setLightMode: () => void;
   setAutoMode: () => void;


### PR DESCRIPTION
Adds a helper to know what theme is actually applied at a given time; if `auto`, then returns what the user's browser preferences are. 

Having trouble getting the styleguide running locally, so haven't been able to test yet. 