### PR TITLE
[search-ui] experimental notes, style tweaks and fixes

### DIFF
--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -1,4 +1,4 @@
-import { Button, Link } from '@expo/styleguide';
+import { Button, Link, mergeClasses } from '@expo/styleguide';
 import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
 import { ThumbsDownIcon } from '@expo/styleguide-icons/outline/ThumbsDownIcon';
 import { ThumbsUpIcon } from '@expo/styleguide-icons/outline/ThumbsUpIcon';
@@ -23,7 +23,7 @@ export function AIPromptResult({ conversation, isGeneratingAnswer, isPreparingAn
   return (
     <>
       <BarLoader isLoading={isLoading} />
-      <div className="result-container flex flex-col gap-4 p-4 w-full">
+      <div className="result-container flex flex-col gap-4 !pt-3 w-full">
         {isPreparingAnswer && (
           <div className="flex text-xs size-full items-center justify-center text-quaternary">Preparing answer...</div>
         )}
@@ -46,11 +46,10 @@ export function AIPromptResult({ conversation, isGeneratingAnswer, isPreparingAn
         />
         {!isLoading && lastConversation?.id && (
           <>
-            <div className="inline-flex items-center w-full gap-2">
+            <div className={mergeClasses('inline-flex items-center w-full gap-2', 'max-md-gutters:flex-col')}>
               <Button
                 skipCapitalization
                 theme="secondary"
-                className="mr-auto"
                 size="xs"
                 leftSlot={<ClipboardIcon />}
                 disabled={copyDone}
@@ -63,39 +62,50 @@ export function AIPromptResult({ conversation, isGeneratingAnswer, isPreparingAn
                 }}>
                 Copy answer
               </Button>
-              <p className="text-tertiary text-2xs">Rate answer:</p>
-              <Button
-                theme="secondary"
-                size="xs"
-                disabled={hasVoted}
-                leftSlot={
-                  hasVoted === true ? (
-                    <ThumbsUpSolidIcon className="text-icon-success" />
-                  ) : (
-                    <ThumbsUpIcon className="text-icon-success" />
-                  )
-                }
-                onClick={() => {
-                  addFeedback?.(lastConversation.id, 'upvote');
-                  setVoted(true);
-                }}
-              />
-              <Button
-                theme="secondary"
-                size="xs"
-                disabled={hasVoted}
-                leftSlot={
-                  hasVoted === false ? (
-                    <ThumbsDownSolidIcon className="text-icon-danger" />
-                  ) : (
-                    <ThumbsDownIcon className="text-icon-danger" />
-                  )
-                }
-                onClick={() => {
-                  addFeedback?.(lastConversation.id, 'downvote');
-                  setVoted(false);
-                }}
-              />
+              <p className={mergeClasses('text-tertiary text-2xs mx-auto', 'max-md-gutters:mt-0.5')}>
+                Expo AI assistant is an experimental feature.
+              </p>
+              <div
+                className={mergeClasses(
+                  'contents items-center w-full gap-x-2 gap-y-3',
+                  'max-md-gutters:justify-center max-md-gutters:inline-flex'
+                )}>
+                <p className="text-tertiary text-2xs">Rate answer:</p>
+                <Button
+                  theme="secondary"
+                  size="xs"
+                  className="shrink-0"
+                  disabled={hasVoted}
+                  leftSlot={
+                    hasVoted === true ? (
+                      <ThumbsUpSolidIcon className="text-icon-success" />
+                    ) : (
+                      <ThumbsUpIcon className="text-icon-success" />
+                    )
+                  }
+                  onClick={() => {
+                    addFeedback?.(lastConversation.id, 'upvote');
+                    setVoted(true);
+                  }}
+                />
+                <Button
+                  theme="secondary"
+                  size="xs"
+                  className="shrink-0"
+                  disabled={hasVoted}
+                  leftSlot={
+                    hasVoted === false ? (
+                      <ThumbsDownSolidIcon className="text-icon-danger" />
+                    ) : (
+                      <ThumbsDownIcon className="text-icon-danger" />
+                    )
+                  }
+                  onClick={() => {
+                    addFeedback?.(lastConversation.id, 'downvote');
+                    setVoted(false);
+                  }}
+                />
+              </div>
             </div>
           </>
         )}

--- a/packages/search-ui/src/components/BarLoader.tsx
+++ b/packages/search-ui/src/components/BarLoader.tsx
@@ -7,7 +7,7 @@ export const BarLoader = ({ isLoading, className }: Props) => (
   <div
     role="progressbar"
     className={mergeClasses(
-      'bg-palette-blue9 h-0.5 absolute mt-[11px] left-px',
+      'bg-palette-blue9 h-0.5 absolute left-px',
       isLoading && 'animate-[searchUIBarLoader_2s_infinite_ease-in-out]',
       className
     )}

--- a/packages/search-ui/src/components/CommandMenuContent.tsx
+++ b/packages/search-ui/src/components/CommandMenuContent.tsx
@@ -130,7 +130,10 @@ export const CommandMenuContent = ({
           }}>
           <div className="inline-flex gap-3 items-center">
             <Stars02Icon className="text-icon-secondary" />
-            <p className="text-xs font-medium">Ask Expo's AI assistant</p>
+            <div className="flex flex-col">
+              <p className="text-xs font-medium leading-snug">Ask Expo's AI assistant</p>
+              <p className="text-2xs text-tertiary leading-snug">Experimental feature</p>
+            </div>
           </div>
         </CommandItemBaseWithCopy>
       </Command.Group>

--- a/packages/search-ui/src/styles/expo-search-ui.css
+++ b/packages/search-ui/src/styles/expo-search-ui.css
@@ -81,7 +81,7 @@
   outline: none;
   padding: 0 44px;
   min-height: 46px;
-  margin: 16px 16px 0;
+  margin: 16px 16px 12px;
   border: 1px solid var(--expo-theme-border-default);
   border-radius: 6px;
   width: calc(100% - 32px);
@@ -139,7 +139,6 @@
   border-top: 1px solid var(--expo-theme-border-default);
   border-bottom: 1px solid var(--expo-theme-border-default);
   padding: 0 16px 12px;
-  margin: 12px 0 0;
 }
 
 .prompt-result {

--- a/packages/search-ui/src/styles/expo-search-ui.css
+++ b/packages/search-ui/src/styles/expo-search-ui.css
@@ -262,3 +262,7 @@ html.dark-theme [cmdk-item][data-selected='true'] mark {
 [cmdk-list]::-webkit-scrollbar-thumb:hover, .result-container::-webkit-scrollbar-thumb:hover {
   background-color: var(--slate-6);
 }
+
+.grecaptcha-badge {
+  visibility: hidden;
+}


### PR DESCRIPTION
# Why

We want to emphasize a bit more the experimental nature of Expo AI assistant feature in Search UI.

# How

Add sub-line to the trigger option, add note in prompt result footer denoting the experimental nature of Expo AI assistant feature.

Update styles based on spotted issue in docs app, tweak prompt result layout in mobile view.

# Preview

![Screenshot 2025-07-10 at 10 48 45](https://github.com/user-attachments/assets/6ec33771-bd23-4448-9204-456b51717471)

![Screenshot 2025-07-10 at 10 47 49](https://github.com/user-attachments/assets/7d7f27a3-9971-46a3-bc66-13cc7fad493f)

![Screenshot 2025-07-10 at 10 48 05](https://github.com/user-attachments/assets/72e55f19-b450-4425-9c0d-c2593ec45f97)
