### PR TITLE
[styleguide] add "preview" semantic color, small tweaks

### DIFF
--- a/packages/example-web/components/ColorTile.tsx
+++ b/packages/example-web/components/ColorTile.tsx
@@ -1,0 +1,29 @@
+import { mergeClasses } from '@expo/styleguide';
+import { PropsWithChildren } from 'react';
+
+import useCopy from '@/hooks/useCopy';
+
+type Props = PropsWithChildren<{
+  className: string;
+  label?: string;
+}>;
+
+export function ColorTile({ children, className, label = className.split('-').at(-1) }: Props) {
+  const [, copy] = useCopy();
+
+  return (
+    <div>
+      <div
+        className={mergeClasses(
+          'mb-1 h-16 w-16 transition',
+          'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
+          'active:!scale-105',
+          className
+        )}
+        onClick={() => copy(className)}>
+        {children}
+      </div>
+      <p className="text-center text-3xs text-secondary">{label}</p>
+    </div>
+  );
+}

--- a/packages/example-web/components/Sidebar.tsx
+++ b/packages/example-web/components/Sidebar.tsx
@@ -8,11 +8,11 @@ import { useSearchDialogContext } from '@/common/SearchDialogContext';
 import { SidebarLink } from '@/components/SidebarLink';
 
 export function Sidebar() {
-  const { themeName, setDarkMode, setLightMode } = useTheme();
+  const { activeTheme, setDarkMode, setLightMode } = useTheme();
   const { setOpen } = useSearchDialogContext();
 
   function toggleTheme() {
-    if (themeName === Themes.AUTO || themeName === Themes.LIGHT) {
+    if (activeTheme === Themes.LIGHT) {
       setDarkMode();
     } else {
       setLightMode();
@@ -45,7 +45,7 @@ export function Sidebar() {
             width="40"
             height="40"
             alt="Expo Styleguide Logo"
-            className="compact-height:block hidden min-w-[40px] max-md-gutters:block"
+            className="hidden min-w-[40px] compact-height:block max-md-gutters:block"
           />
         </Link>
         <CommandMenuTrigger

--- a/packages/example-web/components/Sidebar.tsx
+++ b/packages/example-web/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Button, useTheme, Themes, mergeClasses } from '@expo/styleguide';
+import { Button, mergeClasses, Themes, useTheme } from '@expo/styleguide';
 import { ThemeIcon } from '@expo/styleguide-icons/custom/ThemeIcon';
 import { CommandMenuTrigger } from '@expo/styleguide-search-ui';
 import Image from 'next/image';
@@ -8,11 +8,11 @@ import { useSearchDialogContext } from '@/common/SearchDialogContext';
 import { SidebarLink } from '@/components/SidebarLink';
 
 export function Sidebar() {
-  const { activeTheme, setDarkMode, setLightMode } = useTheme();
+  const { activeTheme, themeName, setDarkMode, setLightMode } = useTheme();
   const { setOpen } = useSearchDialogContext();
 
   function toggleTheme() {
-    if (activeTheme === Themes.LIGHT) {
+    if (themeName === Themes.LIGHT || (themeName === Themes.AUTO && activeTheme === Themes.LIGHT)) {
       setDarkMode();
     } else {
       setLightMode();

--- a/packages/example-web/next.config.js
+++ b/packages/example-web/next.config.js
@@ -8,6 +8,11 @@ const nextConfig = {
   devIndicators: {
     position: 'bottom-right',
   },
+  transpilePackages: ['@expo/*'],
+  experimental: {
+    webpackBuildWorker: true,
+    optimizePackageImports: ['@expo/*'],
+  },
   async redirects() {
     return [
       {

--- a/packages/example-web/pages/colors.tsx
+++ b/packages/example-web/pages/colors.tsx
@@ -1,11 +1,10 @@
 import { mergeClasses } from '@expo/styleguide';
 
 import { getPaletteClasses } from '@/common/utils';
+import { ColorTile } from '@/components/ColorTile';
 import { H1, H3, H4 } from '@/components/headers';
-import useCopy from '@/hooks/useCopy';
 
 export default function ColorsPage() {
-  const [, copy] = useCopy();
   return (
     <>
       <H1>Colors</H1>
@@ -24,39 +23,24 @@ export default function ColorsPage() {
           'bg-warning',
           'bg-danger',
           'bg-info',
+          'bg-preview',
         ].map((className, index) => (
-          <div key={index}>
-            <div
-              className={mergeClasses(
-                'mb-1 h-16 w-16 transition',
-                'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
-                'active:scale-105',
-                className
-              )}
-              onClick={() => copy(className)}
-            />
-            <p className="text-center text-3xs text-secondary">{className.replace('bg-', '')}</p>
-          </div>
+          <ColorTile key={index} className={className} />
         ))}
       </div>
       <H4 className="mt-6">Borders</H4>
       <div className="mb-2 flex flex-wrap">
-        {['border-default', 'border-secondary', 'border-success', 'border-warning', 'border-danger', 'border-info'].map(
-          (className, index) => (
-            <div key={index}>
-              <div
-                className={mergeClasses(
-                  'mb-1 h-16 w-16 border-[10px] transition',
-                  'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
-                  'active:scale-105',
-                  className
-                )}
-                onClick={() => copy(className)}
-              />
-              <p className="text-center text-3xs text-secondary">{className.replace('border-', '')}</p>
-            </div>
-          )
-        )}
+        {[
+          'border-default',
+          'border-secondary',
+          'border-success',
+          'border-warning',
+          'border-danger',
+          'border-info',
+          'border-preview',
+        ].map((className, index) => (
+          <ColorTile key={index} className={mergeClasses('border-[10px]', className)} />
+        ))}
       </div>
       <H4 className="mt-6">Text colors</H4>
       <div className="mb-2 flex flex-wrap">
@@ -69,20 +53,13 @@ export default function ColorsPage() {
           'text-warning',
           'text-danger',
           'text-info',
+          'text-preview',
         ].map((className, index) => (
-          <div key={index}>
-            <div
-              className={mergeClasses(
-                'mb-1 inline-flex h-16 w-16 items-center justify-center font-black transition heading-xl',
-                'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
-                'active:scale-105',
-                className
-              )}
-              onClick={() => copy(className)}>
-              T
-            </div>
-            <p className="text-center text-3xs text-secondary">{className.replace('text-', '')}</p>
-          </div>
+          <ColorTile
+            key={index}
+            className={mergeClasses('flex items-center justify-center font-black heading-2xl', className)}>
+            T
+          </ColorTile>
         ))}
       </div>
       <H3 id="palette">Palette</H3>
@@ -90,21 +67,7 @@ export default function ColorsPage() {
         {['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink', 'gray'].map((color) => (
           <div className="mb-2 flex flex-wrap" key={color}>
             {getPaletteClasses(color).map((className, index) => (
-              <div key={index}>
-                <div
-                  className={mergeClasses(
-                    'mb-1 h-16 w-16 transition',
-                    'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
-                    'active:scale-105',
-                    className
-                  )}
-                  onClick={() => copy(`palette-${color}${index + 1}`)}
-                />
-                <p className="text-center text-3xs text-secondary">
-                  {color}
-                  {index + 1}
-                </p>
-              </div>
+              <ColorTile key={index} className={className} label={`${color}${index + 1}`} />
             ))}
           </div>
         ))}
@@ -125,18 +88,7 @@ export default function ColorsPage() {
           'bg-app-light-green',
           'bg-app-dark-green',
         ].map((className, index) => (
-          <div key={index}>
-            <div
-              className={mergeClasses(
-                'mb-1 h-16 w-16 transition',
-                'hover:shadow-xl hocus:scale-110 hocus:cursor-pointer',
-                'active:scale-105',
-                className
-              )}
-              onClick={() => copy(className)}
-            />
-            <p className="text-center text-3xs text-secondary">{className.replace('bg-app-', '')}</p>
-          </div>
+          <ColorTile key={index} className={className} />
         ))}
       </div>
     </>

--- a/packages/example-web/pages/layouts.tsx
+++ b/packages/example-web/pages/layouts.tsx
@@ -2,10 +2,8 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { H1, H3 } from '@/components/headers';
 
-const VIEWPORT_CLASS = mergeClasses(
-  'mx-auto mt-4 border border-default bg-screen px-6 pt-4 pb-5 rounded-lg shadow-xs'
-);
-const SCREEN_CLASS = mergeClasses('mx-auto mt-4 min-h-28 border border-secondary bg-default px-4 pt-3 rounded-md');
+const VIEWPORT_CLASS = mergeClasses('mx-auto mt-4 rounded-lg border border-default bg-screen px-6 pb-5 pt-4 shadow-xs');
+const SCREEN_CLASS = mergeClasses('mx-auto mt-4 min-h-28 rounded-md border border-secondary bg-default px-4 pt-3');
 
 export default function LayoutsPage() {
   return (

--- a/packages/example-web/pages/typography.tsx
+++ b/packages/example-web/pages/typography.tsx
@@ -29,17 +29,9 @@ export default function TypographyPage() {
         <DemoTile title="text-2xs" className="text-2xs" />
         <DemoTile title="text-3xs" className="text-3xs" />
       </div>
-      <H3 id="elements" className="opacity-80">
-        <span className="line-through">Elements</span> (legacy)
-      </H3>
-      <div className="flex flex-col gap-4 opacity-60">
-        <DemoTile title="Headline" className="text-base font-medium" />
-        <DemoTile title="Paragraph" className="text-base font-normal" />
-        <DemoTile title="Label" className="text-sm font-medium" />
-        <DemoTile title="Callout" className="text-xs" />
-        <DemoTile title="Footnote" className="text-2xs" />
-        <DemoTile title="Caption" className="text-3xs" />
-        <DemoTile tag="code" title="Code" className="text-base" />
+      <H3 id="elements">Raw Elements</H3>
+      <div className="flex flex-col gap-4">
+        <DemoTile tag="code" title="code" className="text-base" />
       </div>
     </>
   );

--- a/packages/example-web/pages/ui/components.tsx
+++ b/packages/example-web/pages/ui/components.tsx
@@ -50,6 +50,12 @@ export default function ComponentsPage() {
           Success text
         </div>
       </DemoTile>
+      <DemoTile title="preview" tag="div">
+        <div className="flex items-center gap-2 rounded-lg border border-preview bg-preview px-3 py-1.5 text-sm text-preview shadow-xs">
+          <EasMetadataIcon className="icon-sm text-icon-preview" />
+          Preview text
+        </div>
+      </DemoTile>
       <H3>Link Base</H3>
       <DemoTile title="local anchor">
         <LinkBase href="#buttons">LinkBase</LinkBase>

--- a/packages/styleguide/src/components/Button/Button.tsx
+++ b/packages/styleguide/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ForwardedRef, forwardRef } from 'react';
+import React, { cloneElement, ForwardedRef, forwardRef, isValidElement, PropsWithChildren } from 'react';
 import type { ReactElement } from 'react';
 
 import { ButtonBase, ButtonBaseProps } from './ButtonBase';
@@ -152,7 +152,7 @@ function getButtonIconClasses(size: ButtonSize) {
 }
 
 function isIconElement(element: ReactElement) {
-  if (React.isValidElement(element)) {
+  if (isValidElement<ReactElement>(element)) {
     // @ts-ignore React Portal did not have `displayName` prop, but it is a valid element
     return element.type?.displayName?.endsWith('Icon') ?? false;
   }
@@ -160,6 +160,9 @@ function isIconElement(element: ReactElement) {
 }
 
 function getIconProps(element: ReactElement, classNames: string) {
+  if (!isValidElement<PropsWithChildren<{ className?: string }>>(element)) {
+    return element;
+  }
   return {
     ...element.props,
     className: mergeClasses(classNames, element.props.className),
@@ -194,6 +197,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
       `inline-flex border border-solid rounded-md font-medium items-center whitespace-nowrap transition gap-2`,
       size === 'xs' && 'gap-1.5',
       size === '2xs' && 'gap-1',
+      size === '2xl' && 'rounded-md',
       getSizeClasses(size),
       getThemeClasses(theme, disabled),
       isSingleIconButton && getButtonIconClasses(size),

--- a/packages/styleguide/src/components/Theme/BlockingSetInitialColorMode.tsx
+++ b/packages/styleguide/src/components/Theme/BlockingSetInitialColorMode.tsx
@@ -47,12 +47,15 @@ export function setInitialColorMode(): void {
   }
 }
 
+const FUNCTION_NAME_REGEX = /function\s+([A-Za-z_$][\w$]*)\s*\(/;
+const match = setInitialColorMode.toString().match(FUNCTION_NAME_REGEX);
+
 // our function needs to be a string so that we can call it
 const blockingSetInitialColorMode = `(function() {
   ${isLocalStorageAvailable.toString()}
   ${getInitialColorMode.toString()}
   ${setInitialColorMode.toString()}
-  setInitialColorMode();
+  ${match?.[1] ?? 'setInitialColorMode'}();
 })()
 `;
 

--- a/packages/styleguide/src/components/Theme/BlockingSetInitialColorMode.tsx
+++ b/packages/styleguide/src/components/Theme/BlockingSetInitialColorMode.tsx
@@ -36,7 +36,7 @@ export function getInitialColorMode(): string | null {
   return 'light';
 }
 
-function setInitialColorMode() {
+export function setInitialColorMode(): void {
   const colorMode = getInitialColorMode();
 
   // add HTML attribute if dark mode

--- a/packages/styleguide/src/styles/expo-theme.css
+++ b/packages/styleguide/src/styles/expo-theme.css
@@ -45,6 +45,7 @@
   --expo-theme-background-warning: var(--amber-3);
   --expo-theme-background-danger: var(--red-3);
   --expo-theme-background-info: var(--blue-3);
+  --expo-theme-background-preview: var(--purple-3);
 
   /* Icons */
   --expo-theme-icon-default: var(--slate-11);
@@ -55,6 +56,7 @@
   --expo-theme-icon-warning: var(--amber-11);
   --expo-theme-icon-danger: var(--red-10);
   --expo-theme-icon-info: var(--blue-10);
+  --expo-theme-icon-preview: var(--purple-10);
 
   /* Text */
   --expo-theme-text-default: var(--slate-12);
@@ -66,6 +68,7 @@
   --expo-theme-text-warning: var(--amber-11);
   --expo-theme-text-danger: var(--red-11);
   --expo-theme-text-info: var(--blue-11);
+  --expo-theme-text-preview: var(--purple-11);
 
   /* Borders */
   --expo-theme-border-default: var(--slate-6);
@@ -74,6 +77,7 @@
   --expo-theme-border-warning: var(--amber-7);
   --expo-theme-border-danger: var(--red-7);
   --expo-theme-border-info: var(--blue-7);
+  --expo-theme-border-preview: var(--purple-7);
 
   /* Buttons */
   --expo-theme-button-primary-background: var(--blue-10);
@@ -170,6 +174,7 @@
   --expo-theme-background-warning: var(--amber-3);
   --expo-theme-background-danger: var(--red-3);
   --expo-theme-background-info: var(--blue-3);
+  --expo-theme-background-preview: var(--purple-3);
 
   /* Icons */
   --expo-theme-icon-default: var(--slate-11);
@@ -180,6 +185,7 @@
   --expo-theme-icon-warning: var(--amber-11);
   --expo-theme-icon-danger: var(--red-10);
   --expo-theme-icon-info: var(--blue-10);
+  --expo-theme-icon-preview: var(--purple-10);
 
   /* Text */
   --expo-theme-text-default: var(--slate-12);
@@ -191,6 +197,7 @@
   --expo-theme-text-warning: var(--amber-11);
   --expo-theme-text-danger: var(--red-11);
   --expo-theme-text-info: var(--blue-11);
+  --expo-theme-text-preview: var(--purple-11);
 
   /* Borders */
   --expo-theme-border-default: var(--slate-6);
@@ -199,6 +206,7 @@
   --expo-theme-border-warning: var(--amber-7);
   --expo-theme-border-danger: var(--red-7);
   --expo-theme-border-info: var(--blue-7);
+  --expo-theme-border-preview: var(--purple-7);
 
   /* Buttons */
   --expo-theme-button-primary-background: hsl(from var(--blue-8) h calc(s + 20) calc(l - 10));

--- a/packages/styleguide/tailwind.js
+++ b/packages/styleguide/tailwind.js
@@ -133,6 +133,7 @@ const expoTailwindConfig = {
     },
     backgroundColor: {
       transparent: 'transparent',
+      current: 'currentColor',
 
       default: 'var(--expo-theme-background-default)',
       screen: 'var(--expo-theme-background-screen)',
@@ -145,6 +146,7 @@ const expoTailwindConfig = {
       warning: 'var(--expo-theme-background-warning)',
       danger: 'var(--expo-theme-background-danger)',
       info: 'var(--expo-theme-background-info)',
+      preview: 'var(--expo-theme-background-preview)',
 
       'button-primary': 'var(--expo-theme-button-primary-background)',
       'button-primary-hover': 'var(--expo-theme-button-primary-hover)',
@@ -175,6 +177,7 @@ const expoTailwindConfig = {
     },
     borderColor: {
       transparent: 'transparent',
+      current: 'currentColor',
 
       default: 'var(--expo-theme-border-default)',
       secondary: 'var(--expo-theme-border-secondary)',
@@ -182,6 +185,7 @@ const expoTailwindConfig = {
       warning: 'var(--expo-theme-border-warning)',
       danger: 'var(--expo-theme-border-danger)',
       info: 'var(--expo-theme-border-info)',
+      preview: 'var(--expo-theme-border-preview)',
 
       'button-primary': 'var(--expo-theme-button-primary-border)',
       'button-primary-disabled': 'var(--expo-theme-button-primary-disabled-border)',
@@ -216,6 +220,7 @@ const expoTailwindConfig = {
       warning: 'var(--expo-theme-text-warning)',
       danger: 'var(--expo-theme-text-danger)',
       info: 'var(--expo-theme-text-info)',
+      preview: 'var(--expo-theme-text-preview)',
 
       'icon-default': 'var(--expo-theme-icon-default)',
       'icon-secondary': 'var(--expo-theme-icon-secondary)',
@@ -225,6 +230,7 @@ const expoTailwindConfig = {
       'icon-warning': 'var(--expo-theme-icon-warning)',
       'icon-danger': 'var(--expo-theme-icon-danger)',
       'icon-info': 'var(--expo-theme-icon-info)',
+      'icon-preview': 'var(--expo-theme-icon-preview)',
 
       'button-primary': 'var(--expo-theme-button-primary-text)',
       'button-primary-icon': 'var(--expo-theme-button-primary-icon)',
@@ -267,6 +273,7 @@ const expoTailwindConfig = {
       warning: 'var(--expo-theme-background-warning)',
       danger: 'var(--expo-theme-background-danger)',
       info: 'var(--expo-theme-background-info)',
+      preview: 'var(--expo-theme-background-preview)',
 
       ...palette,
     },
@@ -409,6 +416,7 @@ const expoTailwindConfig = {
         'bg-warning': 'var(--expo-theme-background-warning)',
         'bg-danger': 'var(--expo-theme-background-danger)',
         'bg-info': 'var(--expo-theme-background-info)',
+        'bg-preview': 'var(--expo-theme-background-preview)',
       },
       fill: {
         'border-default': 'var(--expo-theme-border-default)',
@@ -417,12 +425,16 @@ const expoTailwindConfig = {
         'border-warning': 'var(--expo-theme-border-warning)',
         'border-danger': 'var(--expo-theme-border-danger)',
         'border-info': 'var(--expo-theme-border-info)',
+        'border-preview': 'var(--expo-theme-border-preview)',
       },
       backgroundColor: {
         ...appColors,
       },
       gradientColorStops: {
         ...appColors,
+      },
+      zIndex: {
+        1: '1',
       },
       height: {
         15: '3.75rem',


### PR DESCRIPTION
# How

Summary of changes:
* add `"preview"` semantic color, for new type of `InlineHelp`/`Callout` components
* fix element validation in`Button` helper
* increase the roundness of the largest `Button` variant
* make `BlockingSetInitialColorMode` injection minification proof
* add few common extensions to the Tailwind theme config
* update Example Web app content and theme toggler

### Preview

<img width="1682" height="1100" alt="Screenshot 2025-07-13 at 22 04 23" src="https://github.com/user-attachments/assets/77beb1d3-0513-49b5-888f-a2d1916cbe4c" />

<img width="806" height="714" alt="Screenshot 2025-07-13 at 22 04 42" src="https://github.com/user-attachments/assets/17e0f224-8e4e-4adf-91c2-01d3d1ec93b4" />
