### PR TITLE
[search-ui] Fix line spacing in AI search for header and update "Sources" reference

### DIFF
--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -52,7 +52,7 @@ export function AIPromptResult({
           </div>
         )}
         {lastConversation?.question && (
-          <div className="font-semibold mt-1">Last question: “{lastConversation?.question ?? ''}”</div>
+          <div className="font-semibold mt-1 leading-relaxed">Last question: "{lastConversation?.question ?? ''}"</div>
         )}
         {isPreparingAnswer && (
           <div className="flex text-xs size-full items-center justify-center text-quaternary">

--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -63,21 +63,10 @@ export function AIPromptResult({
         <Markdown
           children={(() => {
             if (!lastConversation?.answer) return '';
-
-            // Process the answer to add periods to source links at sentence endings
             let processedAnswer = lastConversation.answer;
-
-            // First, add "Source:" to all links
             processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[Source: $1]($2)');
-
-            // Then add pipe separators between consecutive source links
             processedAnswer = processedAnswer.replace(/\]\(([^)]+)\)\s*\[/g, ']($1) | [');
-
-            // Finally, add period before the first source link in a sentence
-            // Add period when the preceding text doesn't end with punctuation and is followed by Source:
             processedAnswer = processedAnswer.replace(/([^.!?])\s*\[Source:/g, '$1. [Source:');
-
-            // Clean up: remove any periods that appear after pipe separators
             processedAnswer = processedAnswer.replace(/\|\s*\./g, '|');
 
             return processedAnswer;

--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -61,7 +61,27 @@ export function AIPromptResult({
           </div>
         )}
         <Markdown
-          children={lastConversation?.answer ?? ''}
+          children={(() => {
+            if (!lastConversation?.answer) return '';
+
+            // Process the answer to add periods to source links at sentence endings
+            let processedAnswer = lastConversation.answer;
+
+            // First, add "Source:" to all links
+            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[Source: $1]($2)');
+
+            // Then add pipe separators between consecutive source links
+            processedAnswer = processedAnswer.replace(/\]\(([^)]+)\)\s*\[/g, ']($1) | [');
+
+            // Finally, add period before the first source link in a sentence
+            // Add period when the preceding text doesn't end with punctuation and is followed by Source:
+            processedAnswer = processedAnswer.replace(/([^.!?])\s*\[Source:/g, '$1. [Source:');
+
+            // Clean up: remove any periods that appear after pipe separators
+            processedAnswer = processedAnswer.replace(/\|\s*\./g, '|');
+
+            return processedAnswer;
+          })()}
           options={{
             overrides: {
               a: {

--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -52,7 +52,7 @@ export function AIPromptResult({
           </div>
         )}
         {lastConversation?.question && (
-          <div className="font-semibold mt-1 leading-relaxed">Last question: "{lastConversation?.question ?? ''}"</div>
+          <div className="font-semibold mt-1 leading-relaxed">You asked: "{lastConversation?.question ?? ''}"</div>
         )}
         {isPreparingAnswer && (
           <div className="flex text-xs size-full items-center justify-center text-quaternary">

--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -64,9 +64,10 @@ export function AIPromptResult({
           children={(() => {
             if (!lastConversation?.answer) return '';
             let processedAnswer = lastConversation.answer;
-            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[Source: $1]($2)');
-            processedAnswer = processedAnswer.replace(/\]\(([^)]+)\)\s*\[/g, ']($1) | [');
-            processedAnswer = processedAnswer.replace(/([^.!?])\s*\[Source:/g, '$1. [Source:');
+
+            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, 'Source: [$1]($2)');
+            processedAnswer = processedAnswer.replace(/\]\(([^)]+)\)\s*Source:/g, ']($1) | Source:');
+            processedAnswer = processedAnswer.replace(/([^.!?])\s*Source:/g, '$1. Source:');
             processedAnswer = processedAnswer.replace(/\|\s*\./g, '|');
 
             return processedAnswer;


### PR DESCRIPTION
## Why

Fix ENG-16978 ENG-16979

## Test plan

- Run example-web, open search UI > AI, ask a question.
- Update "Source" references so that sentencs end with a period and references/links are marked with "Source: " prefix.

## Preview

<img width="1584" height="1614" alt="CleanShot 2025-08-11 at 12 51 02@2x" src="https://github.com/user-attachments/assets/c8b5589f-acdc-4470-a4b8-a33ff9da23f0" />


<img width="1612" height="1560" alt="CleanShot 2025-08-11 at 14 24 15@2x" src="https://github.com/user-attachments/assets/1e261f35-7a7e-40ea-b5b3-13c873294f34" />

<img width="1666" height="1586" alt="CleanShot 2025-08-11 at 14 23 27@2x" src="https://github.com/user-attachments/assets/feffea93-8fb3-4e05-bd4a-4e0137bfc37e" />

