### PR TITLE
[search-ui] Multiple improvements for Search and AI modes in Search UI

### DIFF
--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -76,6 +76,10 @@ export function AIPromptResult({
             overrides: {
               a: {
                 component: Link,
+                props: {
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                },
               },
               pre: {
                 component: PromptResultCodeBlock,

--- a/packages/search-ui/src/components/CommandMenuContent.tsx
+++ b/packages/search-ui/src/components/CommandMenuContent.tsx
@@ -115,6 +115,7 @@ export const CommandMenuContent = ({
           resetConversation();
           setLoading(true);
           submitQuery(query);
+          setQuery('');
         }
       }
     }
@@ -288,6 +289,7 @@ export const CommandMenuContent = ({
                 if (!conversation.getLatest()) {
                   setLoading(true);
                   submitQuery(query);
+                  setQuery('');
                 }
               }
               inputRef?.current?.focus();

--- a/packages/search-ui/src/components/CommandMenuContent.tsx
+++ b/packages/search-ui/src/components/CommandMenuContent.tsx
@@ -254,7 +254,7 @@ export const CommandMenuContent = ({
               'hocus:bg-element',
               'active:scale-[0.975]'
             )}>
-            <XIcon className="text-icon-tertiary" onClick={() => setOpen(false)} />
+            <XIcon className="text-icon-tertiary" onClick={() => setQuery('')} />
           </div>
           <Command.Input
             value={query}

--- a/packages/search-ui/src/components/CommandMenuContent.tsx
+++ b/packages/search-ui/src/components/CommandMenuContent.tsx
@@ -79,7 +79,7 @@ export const CommandMenuContent = ({
         setLoading(true);
         const inputTimeout = setTimeout(() => {
           fetchData(() => setLoading(false));
-        }, 150);
+        }, 500);
         return () => clearTimeout(inputTimeout);
       }
     }


### PR DESCRIPTION
## Why

Fixes ENG-17313 ENG-16892

## How/test plan

### Increased the input debounce delay from 150ms to 500ms 

This reduces unnecessary debounce while the user is typing.

**Current behavior**

https://github.com/user-attachments/assets/4b1e9f80-29d8-4ab8-92f9-5a6d6d268b0d

**Improved behavior**

https://github.com/user-attachments/assets/c1676327-21d2-4d76-8a05-7d2a9f83ca77

### All links rendered within AI prompt results now open in a new tab
It uses `rel="noopener noreferrer"` for improved security and user experience

https://github.com/user-attachments/assets/4cb2e2ce-4ef8-4d87-85cd-6b2c1de3169a

## The close (X) icon in the command menu improvements

It now clears the input field instead of closing the menu, making it easier for users to reset their search.

https://github.com/user-attachments/assets/f52e1cbd-4ad7-4f14-8bfa-bf79ca8b1cdc


## AI mode: After submitting a query (via `Enter`), the input field automatically clears

https://github.com/user-attachments/assets/d38c1324-731d-4332-844e-c4acf417d436
