### PR TITLE
[search-ui] Update regex to improve link text references in Ask AI

### DIFF
--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -65,10 +65,15 @@ export function AIPromptResult({
             if (!lastConversation?.answer) return '';
             let processedAnswer = lastConversation.answer;
 
+            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\);/g, '[$1]($2) |');
+            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1]($2)');
+            processedAnswer = processedAnswer.replace(/;/g, ' |');
             processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, 'Source: [$1]($2)');
-            processedAnswer = processedAnswer.replace(/\]\(([^)]+)\)\s*Source:/g, ']($1) | Source:');
-            processedAnswer = processedAnswer.replace(/([^.!?])\s*Source:/g, '$1. Source:');
+            processedAnswer = processedAnswer.replace(/([^.!?|,\s])\s*Source:/g, '$1. Source:');
+            processedAnswer = processedAnswer.replace(/Source:\s*Source:/g, 'Source:');
             processedAnswer = processedAnswer.replace(/\|\s*\./g, '|');
+            processedAnswer = processedAnswer.replace(/\.\s*\|\s*/g, '. ');
+            processedAnswer = processedAnswer.replace(/\[([^\]]*)\](?!\()/g, '$1');
 
             return processedAnswer;
           })()}


### PR DESCRIPTION
## Why

Kapa's link sources are broken on production in Ask AI mode. It seems some changes were made by their team internally, recently, in how they include Markdown links in the answer.

<img width="1464" height="848" alt="CleanShot 2025-09-11 at 02 53 39@2x" src="https://github.com/user-attachments/assets/e9145018-85ab-4c2c-a016-7aa00aa2fcf7" />

<img width="1258" height="260" alt="CleanShot 2025-09-11 at 02 56 39@2x" src="https://github.com/user-attachments/assets/094bd4cd-12da-47b3-a2f1-86a1035fb1c9" />

## How

Update regex patterns to display links in the preferred format.

## Preview

<img width="1386" height="676" alt="CleanShot 2025-09-11 at 02 53 20@2x" src="https://github.com/user-attachments/assets/d1eada6d-6bec-4236-b8e2-192d6ae709d7" />

