### PR TITLE
[docs] Fix broken code format in Ask AI

### DIFF
--- a/packages/search-ui/src/components/AIPromptResult.tsx
+++ b/packages/search-ui/src/components/AIPromptResult.tsx
@@ -17,6 +17,33 @@ type Props = Partial<UseChat> & {
   resetInput: () => void;
 };
 
+function formatAnswer(answer: string) {
+  let processedAnswer = answer;
+
+  console.log('BEFORE -------------> ', processedAnswer);
+
+  processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\);/g, '[$1]($2) |');
+  processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1]($2)');
+  processedAnswer = processedAnswer.replace(/(\]\([^)]+\));/g, '$1 |');
+  processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, 'Source: [$1]($2)');
+  processedAnswer = processedAnswer.replace(/([^.!?|,\s])\s*Source:/g, '$1. Source:');
+  processedAnswer = processedAnswer.replace(/Source:\s*Source:/g, 'Source:');
+  processedAnswer = processedAnswer.replace(/\|\s*\./g, '|');
+  processedAnswer = processedAnswer.replace(/\.\s*\|\s*/g, ' | ');
+  processedAnswer = processedAnswer.replace(/\[([^\]]*)\](?!\()/g, '$1');
+  processedAnswer = processedAnswer.replace(/Source: \[\[/g, 'Source: [');
+  processedAnswer = processedAnswer.replace(/(\]\([^)]+\))\]/g, '$1');
+  processedAnswer = processedAnswer.replace(/\]\]/g, ']');
+  processedAnswer = processedAnswer.replace(/\](\s*\||\s*$)/g, '$1');
+  processedAnswer = processedAnswer.replace(/^\s*•\s*/gm, '- ');
+  processedAnswer = processedAnswer.replace(/^(\s*)(\d+)\)\s*/gm, '$1$2. ');
+  processedAnswer = processedAnswer.replace(/:\s*```/g, ':\n```');
+
+  console.log('AFTER -------------> ', processedAnswer);
+
+  return processedAnswer;
+}
+
 export function AIPromptResult({
   conversation,
   isGeneratingAnswer,
@@ -63,23 +90,7 @@ export function AIPromptResult({
         <Markdown
           children={(() => {
             if (!lastConversation?.answer) return '';
-            let processedAnswer = lastConversation.answer;
-
-            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\);/g, '[$1]($2) |');
-            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1]($2)');
-            processedAnswer = processedAnswer.replace(/(\]\([^)]+\));/g, '$1 |');
-            processedAnswer = processedAnswer.replace(/\[([^\]]+)\]\(([^)]+)\)/g, 'Source: [$1]($2)');
-            processedAnswer = processedAnswer.replace(/([^.!?|,\s])\s*Source:/g, '$1. Source:');
-            processedAnswer = processedAnswer.replace(/Source:\s*Source:/g, 'Source:');
-            processedAnswer = processedAnswer.replace(/\|\s*\./g, '|');
-            processedAnswer = processedAnswer.replace(/\.\s*\|\s*/g, ' | ');
-            processedAnswer = processedAnswer.replace(/\[([^\]]*)\](?!\()/g, '$1');
-            processedAnswer = processedAnswer.replace(/Source: \[\[/g, 'Source: [');
-            processedAnswer = processedAnswer.replace(/(\]\([^)]+\))\]/g, '$1');
-            processedAnswer = processedAnswer.replace(/\]\]/g, ']');
-            processedAnswer = processedAnswer.replace(/\](\s*\||\s*$)/g, '$1');
-
-            return processedAnswer;
+            return formatAnswer(lastConversation.answer);
           })()}
           options={{
             overrides: {


### PR DESCRIPTION
## Why
@kadikraman reported that on Production and Preview deployments, the code formatting is broken. This happened in the processing of data format sent to us by Kapa.

<img width="1756" height="1924" alt="CleanShot 2025-09-19 at 13 41 12@2x" src="https://github.com/user-attachments/assets/ed90f64f-e22f-42e3-a9c4-aca430faa7bc" />

## How

- Add regex pattern to  add only the leading newline before fenced code blocks (:\n```…) so language tags like ts stay attached; the earlier trailing fence rewrite was removed after it proved to strip the language locally. 
- Add regex to normalize bullets (• → -) and 1)-style numbering so Markdown renders correctly.
- Refactored AIPromptResult to route answer strings through a new formatAnswer helper.

## Test plan

Test, maily query "how to use supabase?" in preview.